### PR TITLE
do nothing if not latex or html output

### DIFF
--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -58,8 +58,8 @@ kable_styling <- function(kable_input,
   kable_format <- attr(kable_input, "format")
 
   if (!kable_format %in% c("html", "latex")) {
-    stop("Please specify output format in your kable function. Currently ",
-         "generic markdown table using pandoc is not supported.")
+      message("Currently generic markdown table using pandoc is not supported.")
+      return(kable_input)
   }
   if (kable_format == "html") {
     if (is.null(full_width)) {


### PR DESCRIPTION
```
---
title: "Untitled"
output:
  bookdown::word_document2: default
  bookdown::pdf_book: default
---


```{r cars}
library(knitr)
library(kableExtra)
usepackage_latex('tocloft')
dt <- mtcars[1:5, 1:6]


kable(dt,booktabs = T) %>%
   kable_styling(latex_options = c("striped", "hold_position"), full_width = T)
```

This will works for pdf output, but fail if I want to compile it to docx.

To ensure it works for all documents, I need to write `if...else...` by detecting document output.

I think a message to tell the user that the output document is not supported is enough and it do save user a lot of typing by avoiding the `if...else...` (personally, I hate this).