### PR TITLE
Fix issue in getting caption of table with caption.short

### DIFF
--- a/R/magic_mirror.R
+++ b/R/magic_mirror.R
@@ -63,7 +63,7 @@ magic_mirror_latex <- function(kable_input){
     kable_info$caption.short <- str_match(caption_line, "\\[(.*?)\\]")[2]
     kable_info$caption <- substr(caption_line,
                                  nchar(kable_info$caption.short) + 4,
-                                 nchar(caption_line) - 1)
+                                 nchar(caption_line))
   } else {
     kable_info$caption <- str_match(kable_input, "caption\\{(.*?)\\n")[2]
   }


### PR DESCRIPTION
For table with `caption.short` para, `magic_mirror` lost the last character when reading the caption. This affects the repeat_header for longtable.