### PR TITLE
Fix issue in hold position being used with center default float

### DIFF
--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -354,7 +354,7 @@ styling_latex_full_width <- function(x, table_info) {
 }
 
 styling_latex_position <- function(x, table_info, position, latex_options) {
-  hold_position <- "hold_position" %in% latex_options
+  hold_position <- intersect(c("hold_position", "HOLD_position"), latex_options)
   switch(
     position,
     center = styling_latex_position_center(x, table_info, hold_position),
@@ -367,7 +367,12 @@ styling_latex_position <- function(x, table_info, position, latex_options) {
 
 styling_latex_position_center <- function(x, table_info, hold_position) {
   if (!table_info$table_env & table_info$tabular == "tabular") {
-    return(paste0("\\begin{table}[!h]\n\\centering", x, "\n\\end{table}"))
+    x <- paste0("\\begin{table}\n\\centering", x, "\n\\end{table}")
+    if (hold_position == "hold_position") {
+      x <- styling_latex_hold_position(x)
+    } else {
+      x <- styling_latex_HOLD_position(x)
+    }
   }
   return(x)
 }


### PR DESCRIPTION
By default this Rmd section:

```r
library(knitr)
library(kableExtra)
kable(mtcars, format = "latex", booktabs = T) %>%
  kable_styling(latex_options = c("HOLD_position"))
```
Produces this output (despite the HOLD_position):

```tex
\begin{table}[!h]
\centering
\begin{tabular}{lrrrrrrrrrrr}
\toprule
  & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\
\midrule
```
Which I think is incorrect? This change applies the correct hold environment depending on which hold you want. Giving you:

```tex
\begin{table}[H]
\centering
\begin{tabular}{lrrrrrrrrrrr}
\toprule
  & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\
\midrule
```
