### PR TITLE
question mark support for row_spec added

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -61,6 +61,7 @@ regex_escape <- function(x, double_backslash = FALSE) {
   x <- gsub("\\}", "\\\\}", x)
   x <- gsub("\\*", "\\\\*", x)
   x <- gsub("\\+", "\\\\+", x)
+  x <- gsub("\\?", "\\\\?", x)
   return(x)
 }
 


### PR DESCRIPTION
Fixes #77 

since ? is a special character in a perl regex it has to be escaped to check for a literal question mark