### PR TITLE
Add \leavevmode to \color specification 

### DIFF
--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -179,7 +179,7 @@ latex_column_align_builder <- function(x, width, bold, italic, monospace,
   }
 
   if (!is.null(color)) {
-    color <- paste0("\\\\color", latex_color(color))
+    color <- paste0("\\\\leavevmode\\\\color", latex_color(color))
   }
 
   if (!is.null(background)) {


### PR DESCRIPTION
Using `\color` in latex tables [throws the vertical alignment off somehow](https://tex.stackexchange.com/questions/328043/changing-the-text-color-for-a-cell-does-change-alignment).

The solution (according to this post) is to use `\leavevmode` in addition to `\color`.  This solved the alignment problem for me in my tests.