### PR TITLE
additional options for latex charts

### DIFF
--- a/R/group_rows.R
+++ b/R/group_rows.R
@@ -19,6 +19,10 @@
 #' documents.
 #' @param escape A T/F value showing whether special characters should be
 #' escaped.
+#' @param align Adjust justification of group_label in latex only. Value should be "c" for
+#' centered on row, "r" for right justification, or "l" for left justification. Default
+#' Value is "l"  If using html, the alignment can be set by using the label_row_css
+#' parameter.
 #' @param colnum A numeric that determines how many columns the text should span.
 #' The default setting will have the text span the entire length.
 #'
@@ -32,7 +36,7 @@ group_rows <- function(kable_input, group_label = NULL,
                        index = NULL,
                        label_row_css = "border-bottom: 1px solid;",
                        latex_gap_space = "0.3em",
-                       escape = TRUE, colnum = NULL) {
+                       escape = TRUE, align = "l", colnum = NULL) {
 
   kable_format <- attr(kable_input, "format")
   if (!kable_format %in% c("html", "latex")) {
@@ -43,18 +47,22 @@ group_rows <- function(kable_input, group_label = NULL,
   }
   if (is.null(index)) {
     if (kable_format == "html") {
+      if(!missing(align)) warning("Align parameter is not used in HTML Mode,
+                                    use label_row_css instead.")
       return(group_rows_html(kable_input, group_label, start_row, end_row,
                              label_row_css, escape, colnum))
     }
     if (kable_format == "latex") {
       return(group_rows_latex(kable_input, group_label, start_row, end_row,
-                              latex_gap_space, escape, colnum))
+                              latex_gap_space, escape, align, colnum))
     }
   } else {
     index <- group_row_index_translator(index)
     out <- kable_input
     if (kable_format == "html") {
       for (i in 1:nrow(index)) {
+        if(!missing(align)) warning("Align parameter is not used in HTML Mode,
+                                    use label_row_css instead.")
         out <- group_rows_html(out, index$header[i],
                                index$start[i], index$end[i],
                                label_row_css, escape, colnum)
@@ -64,7 +72,7 @@ group_rows <- function(kable_input, group_label = NULL,
       for (i in 1:nrow(index)) {
         out <- group_rows_latex(out, index$header[i],
                                index$start[i], index$end[i],
-                               latex_gap_space, escape, colnum)
+                               latex_gap_space, escape, align, colnum)
       }
     }
     return(out)
@@ -119,7 +127,7 @@ group_rows_html <- function(kable_input, group_label, start_row, end_row,
 }
 
 group_rows_latex <- function(kable_input, group_label, start_row, end_row,
-                             gap_space, escape, colnum) {
+                             gap_space, escape, align, colnum) {
   table_info <- magic_mirror(kable_input)
   out <- enc2utf8(as.character(kable_input))
 
@@ -142,14 +150,14 @@ group_rows_latex <- function(kable_input, group_label, start_row, end_row,
       "\\\\multicolumn{", ifelse(is.null(colnum),
                                  table_info$ncol,
                                  colnum),
-      "}{l}{\\\\textbf{", group_label,
+      "}{", align, "}{\\\\textbf{", group_label,
       "}}\\\\\\\\\n",
       rowtext
     )
   } else {
     rowtext <- paste0("\\\\hline\n", rowtext)
     new_rowtext <- paste0(
-      "\\\\hline\n\\\\multicolumn{", table_info$ncol, "}{l}{\\\\textbf{",
+      "\\\\hline\n\\\\multicolumn{", table_info$ncol, "}{", align,"}{\\\\textbf{",
       group_label, "}}\\\\\\\\\n", rowtext
     )
   }

--- a/R/group_rows.R
+++ b/R/group_rows.R
@@ -19,7 +19,7 @@
 #' documents.
 #' @param escape A T/F value showing whether special characters should be
 #' escaped.
-#' @param align Adjust justification of group_label in latex only. Value should be "c" for
+#' @param latex_align Adjust justification of group_label in latex only. Value should be "c" for
 #' centered on row, "r" for right justification, or "l" for left justification. Default
 #' Value is "l"  If using html, the alignment can be set by using the label_row_css
 #' parameter.
@@ -36,7 +36,7 @@ group_rows <- function(kable_input, group_label = NULL,
                        index = NULL,
                        label_row_css = "border-bottom: 1px solid;",
                        latex_gap_space = "0.3em",
-                       escape = TRUE, align = "l", colnum = NULL) {
+                       escape = TRUE, latex_align = "l", colnum = NULL) {
 
   kable_format <- attr(kable_input, "format")
   if (!kable_format %in% c("html", "latex")) {
@@ -47,21 +47,21 @@ group_rows <- function(kable_input, group_label = NULL,
   }
   if (is.null(index)) {
     if (kable_format == "html") {
-      if(!missing(align)) warning("Align parameter is not used in HTML Mode,
+      if(!missing(latex_align)) warning("latex_align parameter is not used in HTML Mode,
                                     use label_row_css instead.")
       return(group_rows_html(kable_input, group_label, start_row, end_row,
                              label_row_css, escape, colnum))
     }
     if (kable_format == "latex") {
       return(group_rows_latex(kable_input, group_label, start_row, end_row,
-                              latex_gap_space, escape, align, colnum))
+                              latex_gap_space, escape, latex_align, colnum))
     }
   } else {
     index <- group_row_index_translator(index)
     out <- kable_input
     if (kable_format == "html") {
       for (i in 1:nrow(index)) {
-        if(!missing(align)) warning("Align parameter is not used in HTML Mode,
+        if(!missing(latex_align)) warning("latex_align parameter is not used in HTML Mode,
                                     use label_row_css instead.")
         out <- group_rows_html(out, index$header[i],
                                index$start[i], index$end[i],
@@ -72,7 +72,7 @@ group_rows <- function(kable_input, group_label = NULL,
       for (i in 1:nrow(index)) {
         out <- group_rows_latex(out, index$header[i],
                                index$start[i], index$end[i],
-                               latex_gap_space, escape, align, colnum)
+                               latex_gap_space, escape, latex_align, colnum)
       }
     }
     return(out)
@@ -127,7 +127,7 @@ group_rows_html <- function(kable_input, group_label, start_row, end_row,
 }
 
 group_rows_latex <- function(kable_input, group_label, start_row, end_row,
-                             gap_space, escape, align, colnum) {
+                             gap_space, escape, latex_align, colnum) {
   table_info <- magic_mirror(kable_input)
   out <- enc2utf8(as.character(kable_input))
 
@@ -150,14 +150,14 @@ group_rows_latex <- function(kable_input, group_label, start_row, end_row,
       "\\\\multicolumn{", ifelse(is.null(colnum),
                                  table_info$ncol,
                                  colnum),
-      "}{", align, "}{\\\\textbf{", group_label,
+      "}{", latex_align, "}{\\\\textbf{", group_label,
       "}}\\\\\\\\\n",
       rowtext
     )
   } else {
     rowtext <- paste0("\\\\hline\n", rowtext)
     new_rowtext <- paste0(
-      "\\\\hline\n\\\\multicolumn{", table_info$ncol, "}{", align,"}{\\\\textbf{",
+      "\\\\hline\n\\\\multicolumn{", table_info$ncol, "}{", latex_align,"}{\\\\textbf{",
       group_label, "}}\\\\\\\\\n", rowtext
     )
   }

--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -23,7 +23,8 @@
 #' `scale_down` is useful for super wide table. It will automatically adjust
 #' the table to page width. `repeat_header` in only meaningful in a longtable
 #' environment. It will let the header row repeat on every page in that long
-#' table.
+#' table. `row_label_right` will right justify the row labels and `row_label_center`
+#' will center justify the row labels.  Default justification is left.
 #' @param full_width A `TRUE` or `FALSE` variable controlling whether the HTML
 #' table should have 100\% width. Since HTML and pdf have different flavors on
 #' the preferable format for `full_width`. If not specified, a HTML table will
@@ -190,7 +191,8 @@ pdfTable_styling <- function(kable_input,
 
   latex_options <- match.arg(
     latex_options,
-    c("basic", "striped", "hold_position", "HOLD_position", "scale_down", "repeat_header"),
+    c("basic", "striped", "hold_position", "HOLD_position", "scale_down", "repeat_header",
+      "row_label_right","row_label_center"),
     several.ok = T
   )
 
@@ -249,6 +251,27 @@ pdfTable_styling <- function(kable_input,
 
   out <- structure(out, format = "latex", class = "knitr_kable")
   attr(out, "kable_meta") <- table_info
+
+  if ("row_label_right" %in% latex_options | "row_label_center" %in% latex_options) {
+    if ( "row_label_right" %in% latex_options ) {
+      row_label_orientation <- "r"
+    } else {
+      row_label_orientation <- "c"
+    }
+
+    if(table_info$tabular=="longtable") {
+      out <- sub("\\\\begin\\{longtable\\}\\{l",
+                 paste0("\\begin\\{longtable\\}\\{",
+                        row_label_orientation),
+                 out)
+    } else {
+      out <- sub("\\\\begin\\{tabular\\}\\{l",
+                 paste0("\\begin\\{tabular\\}\\{",
+                        row_label_orientation),
+                 out)
+    }
+  }
+
   return(out)
 }
 

--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -23,8 +23,7 @@
 #' `scale_down` is useful for super wide table. It will automatically adjust
 #' the table to page width. `repeat_header` in only meaningful in a longtable
 #' environment. It will let the header row repeat on every page in that long
-#' table. `row_label_right` will right justify the row labels and `row_label_center`
-#' will center justify the row labels.  Default justification is left.
+#' table.
 #' @param full_width A `TRUE` or `FALSE` variable controlling whether the HTML
 #' table should have 100\% width. Since HTML and pdf have different flavors on
 #' the preferable format for `full_width`. If not specified, a HTML table will
@@ -36,6 +35,9 @@
 #' a `LaTeX` table, if `float_*` is selected, `LaTeX` package `wrapfig` will be
 #' imported.
 #' @param font_size A numeric input for table font size
+#' @param row_label_position A character string determining the justification of the row
+#' labels in a table.  Possible values inclued `l` for left, `c` for center, and `r` for
+#' right.  The default value is `l` for left justifcation.
 #' @param ... extra options for HTML or LaTeX. See `details`.
 #'
 #' @details For LaTeX, extra options includes:
@@ -60,6 +62,7 @@ kable_styling <- function(kable_input,
                           full_width = NULL,
                           position = "center",
                           font_size = NULL,
+                          row_label_position = "l",
                           ...) {
 
   if (length(bootstrap_options) == 1 && bootstrap_options == "basic") {
@@ -89,6 +92,9 @@ kable_styling <- function(kable_input,
     if (is.null(full_width)) {
       full_width <- getOption("kable_styling_full_width", T)
     }
+    if(!missing(row_label_position)) {
+      warning("'row_label_position' is not active for HTML tables yet and parameter will not be used.")
+    }
     return(htmlTable_styling(kable_input,
                              bootstrap_options = bootstrap_options,
                              full_width = full_width,
@@ -103,7 +109,9 @@ kable_styling <- function(kable_input,
                             latex_options = latex_options,
                             full_width = full_width,
                             position = position,
-                            font_size = font_size, ...))
+                            font_size = font_size,
+                            row_label_position = row_label_position,
+                            ...))
   }
 }
 
@@ -187,12 +195,12 @@ pdfTable_styling <- function(kable_input,
                              repeat_header_method = c("append", "replace"),
                              repeat_header_continued = FALSE,
                              stripe_color = "gray!6",
-                             latex_table_env = NULL) {
+                             latex_table_env = NULL,
+                             row_label_position) {
 
   latex_options <- match.arg(
     latex_options,
-    c("basic", "striped", "hold_position", "HOLD_position", "scale_down", "repeat_header",
-      "row_label_right","row_label_center"),
+    c("basic", "striped", "hold_position", "HOLD_position", "scale_down", "repeat_header"),
     several.ok = T
   )
 
@@ -252,22 +260,16 @@ pdfTable_styling <- function(kable_input,
   out <- structure(out, format = "latex", class = "knitr_kable")
   attr(out, "kable_meta") <- table_info
 
-  if ("row_label_right" %in% latex_options | "row_label_center" %in% latex_options) {
-    if ( "row_label_right" %in% latex_options ) {
-      row_label_orientation <- "r"
-    } else {
-      row_label_orientation <- "c"
-    }
-
+  if (row_label_position != "l") {
     if(table_info$tabular=="longtable") {
       out <- sub("\\\\begin\\{longtable\\}\\{l",
                  paste0("\\\\begin\\{longtable\\}\\{",
-                        row_label_orientation),
+                        row_label_position),
                  out)
     } else {
       out <- sub("\\\\begin\\{tabular\\}\\{l",
                  paste0("\\\\begin\\{tabular\\}\\{",
-                        row_label_orientation),
+                        row_label_position),
                  out)
     }
   }

--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -261,12 +261,12 @@ pdfTable_styling <- function(kable_input,
 
     if(table_info$tabular=="longtable") {
       out <- sub("\\\\begin\\{longtable\\}\\{l",
-                 paste0("\\begin\\{longtable\\}\\{",
+                 paste0("\\\\begin\\{longtable\\}\\{",
                         row_label_orientation),
                  out)
     } else {
       out <- sub("\\\\begin\\{tabular\\}\\{l",
-                 paste0("\\begin\\{tabular\\}\\{",
+                 paste0("\\\\begin\\{tabular\\}\\{",
                         row_label_orientation),
                  out)
     }

--- a/tests/visual_tests/add_indent_and_group_rows_pdf.Rmd
+++ b/tests/visual_tests/add_indent_and_group_rows_pdf.Rmd
@@ -30,7 +30,7 @@ dt %>%
   dplyr::mutate(wt = paste0("%", mpg)) %>%
 kable(format = "latex", booktabs = T) %>%
   kable_styling() %>%
-  group_rows("Group 1", 4, 7) %>%
+  group_rows("Group 1", 4, 7, align='r',colnum=3) %>%
   group_rows("Group 2", 8, 10)
 ```
 
@@ -39,7 +39,7 @@ rbind(dt, dt, dt) %>%
 kable(format = "latex", booktabs = T) %>%
   kable_styling() %>%
   group_rows("Group 1", 4, 7) %>%
-  group_rows("Group 2", 8, 10) %>%
+  group_rows("Group 2", 8, 10, align='c') %>%
   group_rows("Group 2", 20, 22)
 
 aa <- mtcars

--- a/tests/visual_tests/add_indent_and_group_rows_pdf.Rmd
+++ b/tests/visual_tests/add_indent_and_group_rows_pdf.Rmd
@@ -30,7 +30,7 @@ dt %>%
   dplyr::mutate(wt = paste0("%", mpg)) %>%
 kable(format = "latex", booktabs = T) %>%
   kable_styling() %>%
-  group_rows("Group 1", 4, 7, align='r',colnum=3) %>%
+  group_rows("Group 1", 4, 7, latex_align='r',colnum=3) %>%
   group_rows("Group 2", 8, 10)
 ```
 
@@ -39,7 +39,7 @@ rbind(dt, dt, dt) %>%
 kable(format = "latex", booktabs = T) %>%
   kable_styling() %>%
   group_rows("Group 1", 4, 7) %>%
-  group_rows("Group 2", 8, 10, align='c') %>%
+  group_rows("Group 2", 8, 10, latex_align='c') %>%
   group_rows("Group 2", 20, 22)
 
 aa <- mtcars


### PR DESCRIPTION
Allow for greater control on positioning of row labels in LaTeX with some features available in HTML.  The label align for html would have required multiple line substitutions which made me uncomfortable that a random line could accidentally be changed.  The option to adjust row label orientation is available through the html css parameter if needed.
