### PR TITLE
Non-English text in kable_as_image 

### DIFF
--- a/R/kable_as_image.R
+++ b/R/kable_as_image.R
@@ -28,7 +28,9 @@
 #' `jpeg`, `gif`, `tiff`, etc. Default is `png`.
 #' @param latex_header_includes A character vector of extra LaTeX header stuff.
 #' Each element is a row. You can have things like
-#' `c("\\\\usepackage{threeparttable}", "\\\\usepackage{icons}")`
+#' `c("\\\\usepackage{threeparttable}", "\\\\usepackage{icons}")`  You could
+#' probably add your language package here if you use non-English text in your
+#' table, such as `\\\\usepackage[magyar]{babel}`.
 #' @param keep_pdf A T/F option to control if the mid-way standalone pdf should
 #' be kept. Default is `FALSE`.
 #' @param density Resolution to read the PDF file. Default value is 300, which

--- a/R/kable_as_image.R
+++ b/R/kable_as_image.R
@@ -70,7 +70,7 @@ kable_as_image <- function(kable_input, filename = NULL,
     )
     temp_tex <- paste(temp_tex, collapse = "\n")
     temp_file <- paste0("table_", format(Sys.time(), "%Y-%m-%d_%H%M%S"))
-    writeLines(temp_tex, paste0(temp_file, ".tex"))
+    writeLines(temp_tex, paste0(temp_file, ".tex"), useBytes = T)
     system(paste0("xelatex -interaction=batchmode ", temp_file, ".tex"))
     temp_file_delete <- paste0(temp_file, c(".tex", ".aux", ".log"))
     if(!keep_tex) {

--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -49,6 +49,11 @@
 #' such as tabu or tabularx.You shouldn't expect all features could be
 #' supported in self-defined environments.
 #'
+#' @details  For LaTeX, if you use other than English environment
+#' - all tables are converted to 'UTF-8'. If you use, for example, Hungarian
+#' characters on a Windows machine, make sure to use
+#' Sys.setlocale("LC_ALL","Hungarian") to avoid unexpected conversions.
+#'
 #' @examples x_html <- knitr::kable(head(mtcars), "html")
 #' kable_styling(x_html, "striped", position = "left", font_size = 7)
 #'

--- a/R/util.R
+++ b/R/util.R
@@ -113,6 +113,8 @@ latex_pkg_list <- function() {
     "\\usepackage{threeparttable}",
     "\\usepackage{threeparttablex}",
     "\\usepackage[normalem]{ulem}",
+    "\\usepackage[normalem]{ulem}",
+    "\\usepackage[utf8]{inputenc}",
     "\\usepackage{makecell}"
   ))
 }
@@ -140,6 +142,7 @@ fix_duplicated_rows_latex <- function(kable_input, table_info) {
 
 # Solve enc issue for LaTeX tables
 solve_enc <- function(x) {
+  #may behave differently based on Sys.setlocale settings with respect to characters
   enc2utf8(as.character(base::format(x, trim = TRUE, justify = 'none')))
 }
 

--- a/man/kable_as_image.Rd
+++ b/man/kable_as_image.Rd
@@ -21,7 +21,9 @@ here.}
 
 \item{latex_header_includes}{A character vector of extra LaTeX header stuff.
 Each element is a row. You can have things like
-\code{c("\\\\usepackage{threeparttable}", "\\\\usepackage{icons}")}}
+\code{c("\\\\usepackage{threeparttable}", "\\\\usepackage{icons}")}  You could
+probably add your language package here if you use non-English text in your
+table, such as \code{\\\\usepackage[magyar]{babel}}.}
 
 \item{keep_pdf}{A T/F option to control if the mid-way standalone pdf should
 be kept. Default is \code{FALSE}.}

--- a/man/kable_styling.Rd
+++ b/man/kable_styling.Rd
@@ -68,6 +68,13 @@ replace the caption.
 such as tabu or tabularx.You shouldn't expect all features could be
 supported in self-defined environments.
 }
+
+For LaTeX, if you use other than English environment
+\itemize{
+\item all tables are converted to 'UTF-8'. If you use, for example, Hungarian
+characters on a Windows machine, make sure to use
+Sys.setlocale("LC_ALL","Hungarian") to avoid unexpected conversions.
+}
 }
 \examples{
 x_html <- knitr::kable(head(mtcars), "html")


### PR DESCRIPTION
Please see my explanation at [issue 2018](https://github.com/haozhu233/kableExtra/issues/208). I think what I made makes sense and necessary on Window, but please review especially the addition of 

writeLines(temp_tex, paste0(temp_file, ".tex"), **useBytes = T)**

in `kable_as_image()`