### PR TITLE
Workaround to not execute undefined functions.

### DIFF
--- a/inst/kePrint-0.0.1/kePrint.js
+++ b/inst/kePrint-0.0.1/kePrint.js
@@ -1,4 +1,8 @@
 $(document).ready(function(){
-    $('[data-toggle="tooltip"]').tooltip();
-    $('[data-toggle="popover"]').popover();
+    if (typeof $('[data-toggle="tooltip"]').tooltip === 'function') {
+        $('[data-toggle="tooltip"]').tooltip();
+    }
+    if ($('[data-toggle="popover"]').popover === 'function') {
+        $('[data-toggle="popover"]').popover();
+    }
 });


### PR DESCRIPTION
tooltip() and popover() are defined in bootstrap.min.js, which is not included
when building a bookdown book. This change doesn't execute these two functions
if they are not defined elsewhere. This should be a temporary workround.

Toward haozhu233/kableExtra issue #263.