### PR TITLE
The old align could be "l", matching the "l" in "tabular".

### DIFF
--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -230,7 +230,8 @@ column_spec_latex <- function(kable_input, column, width,
 
   kable_align_new <- paste(table_info$align_vector, collapse = align_collapse)
 
-  out <- sub(kable_align_old, kable_align_new,
+  out <- sub(paste0("\\[", kable_align_old, "\\]"),
+             paste0("\\[", kable_align_new, "\\]"),
              solve_enc(kable_input),
              perl = T)
 

--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -230,8 +230,8 @@ column_spec_latex <- function(kable_input, column, width,
 
   kable_align_new <- paste(table_info$align_vector, collapse = align_collapse)
 
-  out <- sub(paste0("\\[", kable_align_old, "\\]"),
-             paste0("\\[", kable_align_new, "\\]"),
+  out <- sub(paste0("\\{", kable_align_old, "\\}"),
+             paste0("\\{", kable_align_new, "\\}"),
              solve_enc(kable_input),
              perl = T)
 


### PR DESCRIPTION
A question on StackOverflow (https://stackoverflow.com/q/53797603/2554330) found that a simple one column table wouldn't compile when `column_spec` was used to modify it.  The problem was that the original alignment was just "l", and when `column_spec_latex` put in the new one, it replaced the "l" in "tabular" instead of the alignment "l".

