### PR TITLE
Add the examples to kable_as_image.R 

### DIFF
--- a/R/as_image.R
+++ b/R/as_image.R
@@ -14,7 +14,15 @@
 #'
 #' @param ... Additional arguments passed to save_kable.
 #'
+#' @examples
+#' \dontrun{
+#' library(kableExtra)
 #'
+#' kable(mtcars, "latex", booktabs = T) %>%
+#' kable_styling(latex_options = c("striped", "scale_down")) %>%
+#' row_spec(1, color = "red") %>%
+#' as_image()
+#' }
 #' @export
 as_image <- function(x, width = NULL, height = NULL, file = NULL, ...) {
   if (is.null(width) + is.null(height) == 0) {

--- a/R/kable_as_image.R
+++ b/R/kable_as_image.R
@@ -21,20 +21,6 @@
 #' @param keep_tex A T/F option to control if the latex file that is initially created
 #' should be kept. Default is `FALSE`.
 #'
-#' @examples
-#' \dontrun{
-#' library(kableExtra)
-#'
-#' kable(mtcars[1:5, ], "html") %>%
-#'   kable_styling("striped") %>%
-#'   row_spec(1, color = "red") %>%
-#'   save_kable("inst/test.pdf")
-#'
-#' kable(mtcars, "latex", booktabs = T) %>%
-#' kable_styling(latex_options = c("striped", "scale_down")) %>%
-#' row_spec(1, color = "red") %>%
-#' as_image()
-#' }
 #' @export
 kable_as_image <- function(kable_input, filename = NULL,
                            file_format = "png",

--- a/R/kable_as_image.R
+++ b/R/kable_as_image.R
@@ -21,6 +21,20 @@
 #' @param keep_tex A T/F option to control if the latex file that is initially created
 #' should be kept. Default is `FALSE`.
 #'
+#' @examples
+#' \dontrun{
+#' library(kableExtra)
+#'
+#' kable(mtcars[1:5, ], "html") %>%
+#'   kable_styling("striped") %>%
+#'   row_spec(1, color = "red") %>%
+#'   save_kable("inst/test.pdf")
+#'
+#' kable(mtcars, "latex", booktabs = T) %>%
+#' kable_styling(latex_options = c("striped", "scale_down")) %>%
+#' row_spec(1, color = "red") %>%
+#' as_image()
+#' }
 #' @export
 kable_as_image <- function(kable_input, filename = NULL,
                            file_format = "png",

--- a/R/save_kable.R
+++ b/R/save_kable.R
@@ -18,7 +18,15 @@
 #' table, such as `\\\\usepackage[magyar]{babel}`.
 #' @param keep_tex A T/F option to control if the latex file that is initially created
 #' should be kept. Default is `FALSE`.
+#' @examples
+#' \dontrun{
+#' library(kableExtra)
 #'
+#' kable(mtcars[1:5, ], "html") %>%
+#'   kable_styling("striped") %>%
+#'   row_spec(1, color = "red") %>%
+#'   save_kable("inst/test.pdf")
+#' }
 #' @export
 save_kable <- function(x, file,
                        bs_theme = "simplex", self_contained = TRUE,

--- a/man/kable_as_image.Rd
+++ b/man/kable_as_image.Rd
@@ -37,3 +37,18 @@ should be kept. Default is \code{FALSE}.}
 \description{
 deprecated
 }
+\examples{
+\dontrun{
+library(kableExtra)
+
+kable(mtcars[1:5, ], "html") \%>\%
+  kable_styling("striped") \%>\%
+  row_spec(1, color = "red") \%>\%
+  save_kable("inst/test.pdf")
+
+kable(mtcars, "latex", booktabs = T) \%>\%
+kable_styling(latex_options = c("striped", "scale_down")) \%>\%
+row_spec(1, color = "red") \%>\%
+as_image()
+}
+}


### PR DESCRIPTION
From this issue https://github.com/haozhu233/kableExtra/issues/365, I add two examples for this function.

1. from this [tutorial](https://github.com/haozhu233/kableExtra/issues/365), and 
1. update the help document.