### PR TITLE
support for 'distill' markdown articles

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,7 +23,8 @@
   if (!is.null(rmarkdown::metadata$output) &&
       rmarkdown::metadata$output %in% c(
         "ioslides_presentation", "slidy_presentation",
-        "gitbook", "radix_article"
+        "gitbook", "radix_article",
+        "distill_article"
       )) {
     options(kableExtra.html.bsTable = TRUE)
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,8 +23,8 @@
   if (!is.null(rmarkdown::metadata$output) &&
       rmarkdown::metadata$output %in% c(
         "ioslides_presentation", "slidy_presentation",
-        "gitbook", "radix_article",
-        "distill_article"
+        "gitbook", "bookdown::gitbook", "radix_article", "radix::radix_article",
+        "distill_article", "distill::distill_article"
       )) {
     options(kableExtra.html.bsTable = TRUE)
   }


### PR DESCRIPTION
The 'radix' package has been renamed to 'distill'.  (Reference: https://rstudio.github.io/distill/migrating.html)

Similar to #279, it looks like the `options(kableExtra.html.bsTable = TRUE)` needs to be set.  When I set the option explicitly in the Rmd file, the CSS works.

To support it in kableExtra, I followed the guidance in the [using_kableExtra_in_radix vignette](https://haozhu233.github.io/kableExtra/using_kableExtra_in_radix.html) for this PR.
>If you want to this kind of native support to other html format, please submit a PR and add the template name to this line.

But please check me, because I don't think it's working correctly.