### PR TITLE
Fix issue #367

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kableExtra
 Type: Package
 Title: Construct Complex Table with 'kable' and Pipe Syntax
-Version: 1.1.0.9000
+Version: 1.1.0.9100
 Authors@R: c(
     person('Hao', 'Zhu', email = 'haozhu233@gmail.com', role = c('aut', 'cre'),
     comment = c(ORCID = '0000-0002-3386-6076')),

--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -170,6 +170,7 @@ htmlTable_new_header_generator <- function(header_df, bold, italic, monospace,
     row_style <- paste0(row_style, extra_css)
   }
 
+  if (is.null(angle)) {angle = 0}
   if (!is.null(angle)) {
     angle <- paste0("-webkit-transform: rotate(", angle,
                     "deg); -moz-transform: rotate(", angle,


### PR DESCRIPTION
`include_empty` did not work if `angle = NULL` (See issue [#367 ](https://github.com/haozhu233/kableExtra/issues/367))

The `include_empty` code was nested in a `if (!is.null(angle))` statement. 

I have set `angle = 0` if `angle = NULL` for the HTML case, allowing `include_empty` to function correctly. 

Feel free to correct this in a more consistent way. 
Could also set default behaviour of `add_header_above()` to be `angle = 0`