### PR TITLE
Fix issue #387

### DIFF
--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -58,6 +58,8 @@ add_header_above <- function(kable_input, header = NULL,
                              escape = TRUE, line = TRUE, line_sep = 3,
                              extra_css = NULL, include_empty = FALSE,
                              border_left = FALSE, border_right = FALSE) {
+  if (is.null(header)) return(kable_input)
+
   kable_format <- attr(kable_input, "format")
   if (!kable_format %in% c("html", "latex")) {
     warning("Please specify format in kable. kableExtra can customize either ",
@@ -86,7 +88,6 @@ htmlTable_add_header_above <- function(kable_input, header, bold, italic,
                                        align, color, background, font_size,
                                        angle, escape, line, line_sep,
                                        extra_css, include_empty) {
-  if (is.null(header)) return(kable_input)
   kable_attrs <- attributes(kable_input)
   kable_xml <- read_kable_as_xml(kable_input)
   kable_xml_thead <- xml_tpart(kable_xml, "thead")


### PR DESCRIPTION
Moves handling of is.null(header) into add_header_above so it applies to both html and latex formats.  Now if no header is specified, add_header_above returns the kable_input without modification.