### PR TITLE
Allow standardized data frame as input to add_header_above

### DIFF
--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -10,6 +10,10 @@
 #' for a 3-column table with "title" spanning across column 2 and 3. For
 #' convenience, when `colspan` equals to 1, users can drop the ` = 1` part.
 #' As a result, `c(" ", "title" = 2)` is the same as `c(" " = 1, "title" = 2)`.
+#' Alternatively, a data frame with two columns can be provided: The first
+#' column should contain the header names (character vector) and the second 
+#' column should contain the colspan (numeric vector). This input can be used
+#' if there are problems with unicode characters in the headers.
 #' @param bold A T/F value to control whether the text should be bolded.
 #' @param italic A T/F value to control whether the text should to be emphasized.
 #' @param monospace A T/F value to control whether the text of the selected column
@@ -87,12 +91,27 @@ htmlTable_add_header_above <- function(kable_input, header, bold, italic,
                                        angle, escape, line, line_sep,
                                        extra_css, include_empty) {
   if (is.null(header)) return(kable_input)
+   
   kable_attrs <- attributes(kable_input)
   kable_xml <- read_kable_as_xml(kable_input)
   kable_xml_thead <- xml_tpart(kable_xml, "thead")
-
-  header <- standardize_header_input(header)
-
+  
+  if (is.data.frame(header)){
+    if(ncol(header) == 2 & is.character(header[[1]]) & is.numeric(header[[2]]){
+      header <- data.frame(header = header[[1]], colspan = header[[2]])
+    }
+    else {
+      stop("If header input is provided as a data frame instead of a named vector ",
+           "it must consist of only two columns: ",
+           "The first should be a character vector with ",
+           "header names and the second should be a numeric vector with ",
+           "the number of columns the header should span.")
+    }
+  }
+  else {
+    header <- standardize_header_input(header)
+  }
+  
   if (escape) {
     header$header <- escape_html(header$header)
   }
@@ -216,7 +235,22 @@ pdfTable_add_header_above <- function(kable_input, header, bold, italic,
                                       escape, line, line_sep,
                                       border_left, border_right) {
   table_info <- magic_mirror(kable_input)
-  header <- standardize_header_input(header)
+  
+  if (is.data.frame(header)){
+    if(ncol(header) == 2 & is.character(header[[1]]) & is.numeric(header[[2]]){
+      header <- data.frame(header = header[[1]], colspan = header[[2]])
+    }
+    else {
+      stop("If header input is provided as a data frame instead of a named vector ",
+           "it must consist of only two columns: ",
+           "The first should be a character vector with ",
+           "header names and the second should be a numeric vector with ",
+           "the number of columns the header should span.")
+    }
+  }
+  else {
+    header <- standardize_header_input(header)
+  }
 
   if (escape) {
     header$header <- input_escape(header$header, align)

--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -97,7 +97,7 @@ htmlTable_add_header_above <- function(kable_input, header, bold, italic,
   kable_xml_thead <- xml_tpart(kable_xml, "thead")
   
   if (is.data.frame(header)){
-    if(ncol(header) == 2 & is.character(header[[1]]) & is.numeric(header[[2]]){
+    if(ncol(header) == 2 & is.character(header[[1]]) & is.numeric(header[[2]])){
       header <- data.frame(header = header[[1]], colspan = header[[2]])
     }
     else {
@@ -237,7 +237,7 @@ pdfTable_add_header_above <- function(kable_input, header, bold, italic,
   table_info <- magic_mirror(kable_input)
   
   if (is.data.frame(header)){
-    if(ncol(header) == 2 & is.character(header[[1]]) & is.numeric(header[[2]]){
+    if(ncol(header) == 2 & is.character(header[[1]]) & is.numeric(header[[2]])){
       header <- data.frame(header = header[[1]], colspan = header[[2]])
     }
     else {

--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -98,7 +98,8 @@ htmlTable_add_header_above <- function(kable_input, header, bold, italic,
   
   if (is.data.frame(header)){
     if(ncol(header) == 2 & is.character(header[[1]]) & is.numeric(header[[2]])){
-      header <- data.frame(header = header[[1]], colspan = header[[2]])
+      header <- data.frame(header = header[[1]], colspan = header[[2]],
+                           stringsAsFactors = FALSE)
     }
     else {
       stop("If header input is provided as a data frame instead of a named vector ",
@@ -238,7 +239,8 @@ pdfTable_add_header_above <- function(kable_input, header, bold, italic,
   
   if (is.data.frame(header)){
     if(ncol(header) == 2 & is.character(header[[1]]) & is.numeric(header[[2]])){
-      header <- data.frame(header = header[[1]], colspan = header[[2]])
+      header <- data.frame(header = header[[1]], colspan = header[[2]],
+                           stringsAsFactors = FALSE)
     }
     else {
       stop("If header input is provided as a data frame instead of a named vector ",

--- a/R/group_rows.R
+++ b/R/group_rows.R
@@ -126,6 +126,10 @@ group_rows_html <- function(kable_input, group_label, start_row, end_row,
   if (!is.null(group_header_rows)) {
     group_seq <- positions_corrector(group_seq, group_header_rows,
                                      length(xml_children(kable_tbody)))
+    # Update the old group_header_rows attribute with their new positions
+    kable_attrs$group_header_rows <- ifelse(kable_attrs$group_header_rows > group_seq[1],
+                                            kable_attrs$group_header_rows+1,
+                                            kable_attrs$group_header_rows)
   }
 
   # Insert a group header row

--- a/R/util.R
+++ b/R/util.R
@@ -152,8 +152,12 @@ fix_duplicated_rows_latex <- function(kable_input, table_info) {
 
 # Solve enc issue for LaTeX tables
 solve_enc <- function(x) {
+  if (Encoding(x) == "UTF-8"){
+    out <- x
+  } else {
   #may behave differently based on Sys.setlocale settings with respect to characters
-  out <- enc2utf8(as.character(base::format(x, trim = TRUE, justify = 'none')))
+    out <- enc2utf8(as.character(base::format(x, trim = TRUE, justify = 'none')))
+  }
   mostattributes(out) <- attributes(x)
   return(out)
 }


### PR DESCRIPTION
Allow a two column data frame as input instead of a named vector. I experienced issues with unicode characters in the names of named vectors on Windows 10 - the unicode characters were converted and lost. These issues could be side stepped if the input is a two column data frame with a character vector with the header names and a numeric vector with the column spans (same as output from standardize_header_input).

Also, with Windows 10 and locale = Danish_Denmark.1252, the base::format function in solve_enc messed up the encoding if the string was already encoded in UTF-8, e.g. character string = "\u2265".

With these two changes it was possible for me to use add_header_above to add headers containing unicode characters (e.g. "\u2265") on both a machine running Windows 10 and on a Mac running MacOS Mojave.