### PR TITLE
Improve spacing between table and footer

### DIFF
--- a/R/footnote.R
+++ b/R/footnote.R
@@ -339,11 +339,11 @@ latex_tfoot_maker_ <- function(ft_contents, ft_title, ft_chunk, ncol) {
   }
   if (!ft_chunk) {
     footnote_text <- paste0(
-      '\\\\multicolumn{', ncol, '}{l}{', footnote_text, '}\\\\\\\\'
+      '\\\\multicolumn{', ncol, '}{l}{\\\\rule{0pt}{1em}', footnote_text, '}\\\\\\\\'
     )
   } else {
     footnote_text <- paste0(
-      '\\\\multicolumn{', ncol, '}{l}{',
+      '\\\\multicolumn{', ncol, '}{l}{\\\\rule{0pt}{1em}',
       paste0(footnote_text, collapse = " "),
       '}\\\\\\\\'
     )


### PR DESCRIPTION
At present there is quite a small gap between the table and a footer in LaTeX table. Superscript asterisk for example overlaps the table bottomrule. This fixes the issue.

Let me know if there are any issues with this request, I am quite new to contributing.