### PR TITLE
Fix Issues 444 and 401

### DIFF
--- a/R/save_kable.R
+++ b/R/save_kable.R
@@ -144,7 +144,7 @@ save_kable_latex <- function(x, file, latex_header_includes, keep_tex) {
 
   owd <- setwd(dirname(temp_tex_file))
 
-  system(paste0("xelatex -interaction=batchmode ", temp_tex_file))
+  system(paste0('xelatex -interaction=batchmode "', temp_tex_file,'"'))
   if (!keep_tex) {
     temp_file_delete <- paste0(file_no_ext, c(".tex", ".aux", ".log"))
     unlink(temp_file_delete)


### PR DESCRIPTION
Added double quotes around temp_tex_file in xelatex call to accommodate file paths with a space. Fixes #444 and there is a good chance fixes #401. 

Note that adding single quotes (') will not work in windows, it has to be a double quote ("). See below for tests: 

```
library(kableExtra)

dir.create("test_folder")
dir.create("test folder")

#works in both the update and the current code. 
kable(mtcars, "latex", booktabs = T) %>%
  as_image(file="./test_folder/testfile.png")

#fails in current master branch. Will run successfully after this fix since temp_tex_file is double quoted. 
kable(mtcars, "latex") %>%
  as_image(file="./test folder/testfile.png")
```