### PR TITLE
save_kable("file.tex") writes to file

### DIFF
--- a/R/save_kable.R
+++ b/R/save_kable.R
@@ -122,6 +122,14 @@ remove_html_doc <- function(x){
 }
 
 save_kable_latex <- function(x, file, latex_header_includes, keep_tex, density) {
+
+  # if file extension is .tex, write to file, return the table as an
+  # invisible string, and do nothing else
+  if (tools::file_ext(file) == "tex") {
+    writeLines(x, file, useBytes = T)
+    return(invisible(x))
+  }
+
   temp_tex <- c(
     "\\documentclass[border=1mm, preview]{standalone}",
     "\\usepackage[active,tightpage]{preview}",


### PR DESCRIPTION
This PR implements the simplest strategy I could think of to solve issue https://github.com/haozhu233/kableExtra/issues/496

At the very top of the `save_kable_latex` function, we check if the file extension is `.tex`. If it is, we write the table (`x`) to file, return an invisible string with the table in it, and we do nothing else. If the file extension is *not* `.tex`, the function proceeds as before, often creating a PDF or image.

This code:

```r
library(kableExtra)
library(magrittr)

data.frame(a = 1:3, b = 2:4) %>%
  kbl("latex", booktabs=TRUE)  %>%
  kable_styling() %>%
  save_kable(tab, file="test.tex")
```

produces this file:

```latex
\begin{table}[H]
\centering
\begin{tabular}[t]{rr}
\toprule
a & b\\
\midrule
1 & 2\\
2 & 3\\
3 & 4\\
\bottomrule
\end{tabular}
\end{table}
```

Improvements could include the possibility to save standalone LaTeX files, including `\begin{document}` etc., but this PR has the benefit of being extremely simple, and of solving my own use-case ;-)