### PR TITLE
row_spec(hline_after) uses midrule for booktabs

### DIFF
--- a/R/row_spec.R
+++ b/R/row_spec.R
@@ -310,7 +310,11 @@ latex_new_row_builder <- function(target_row, table_info,
   } else {
     latex_after <- "\\\\\\\\"
     if (hline_after) {
-      latex_after <- paste0(latex_after, "\n\\\\hline")
+      if (table_info$booktabs) {
+        latex_after <- paste0(latex_after, "\n\\\\midrule")
+      } else {
+        latex_after <- paste0(latex_after, "\n\\\\hline")
+      }
     }
     if (!is.null(extra_latex_after)) {
       latex_after <- paste0(latex_after, "\n",


### PR DESCRIPTION
`hline` looks out of place in LaTeX when the rest of the table uses `booktabs`. This detects the proper rule type with a condition on `table_info$booktabs`, and uses either `hline` or `midrule` appropriately.

3 new lines of code.


``` r
library(kableExtra)
kbl(data.frame(a = 1:5), "latex", booktabs=TRUE) %>% 
  row_spec(row=2, hline_after=TRUE) %>%
  cat
#> 
#> \begin{tabular}[t]{r}
#> \toprule
#> a\\
#> \midrule
#> 1\\
#> 2\\
#> \midrule
#> 3\\
#> 4\\
#> 5\\
#> \bottomrule
#> \end{tabular}
```

<sup>Created on 2020-09-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>