### PR TITLE
mini plots base::range(na.rm=TRUE)

### DIFF
--- a/R/mini_plots.R
+++ b/R/mini_plots.R
@@ -38,7 +38,7 @@ spec_hist <- function(x, width = 200, height = 50, res = 300,
                       file_type = if (is_latex()) "pdf" else "svg", ...) {
   if (is.list(x)) {
     if (same_lim & is.null(lim)) {
-      lim <- base::range(unlist(x))
+      lim <- base::range(unlist(x), na.rm=TRUE)
     }
 
     dots <- listify_args(x, width, height, res, breaks,
@@ -51,7 +51,7 @@ spec_hist <- function(x, width = 200, height = 50, res = 300,
   if (is.null(x)) return(NULL)
 
   if (is.null(lim)) {
-    lim <- base::range(x)
+    lim <- base::range(x, na.rm=TRUE)
   }
 
   if (!dir.exists(dir)) {
@@ -131,7 +131,7 @@ spec_boxplot <- function(x, width = 200, height = 50, res = 300,
                          file_type = if (is_latex()) "pdf" else "svg", ...) {
   if (is.list(x)) {
     if (same_lim & is.null(lim)) {
-      lim <- base::range(unlist(x))
+      lim <- base::range(unlist(x), na.rm=TRUE)
     }
 
     dots <- listify_args(x, width, height, res,
@@ -145,7 +145,7 @@ spec_boxplot <- function(x, width = 200, height = 50, res = 300,
   if (is.null(x)) return(NULL)
 
   if (is.null(lim)) {
-    lim <- base::range(x)
+    lim <- base::range(x, na.rm=TRUE)
     lim[1] <- lim[1] - (lim[2] - lim[1]) / 10
     lim[2] <- (lim[2] - lim[1]) / 10 + lim[2]
   }


### PR DESCRIPTION
Currently, mini plots do not work if there are missing values in the supplied `x` list of vectors. I added `na.rm=TRUE` to `base::range` and it works.

MWE:

```r
library(kableExtra)

full = miss = lapply(1:5, function(...) rnorm(100))
miss[[1]][1] = miss[[2]][10] = NA

# Works
kbl(data.frame(a = 1:5, b = 1:5)) %>%
  column_spec(2, image=spec_hist(full, same_lim=FALSE))

# Does not work
kbl(data.frame(a = 1:5, b = 1:5)) %>%
  column_spec(2, image=spec_hist(miss, same_lim=FALSE))
```
