### PR TITLE
Remove duplicated LaTeX package

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -108,7 +108,6 @@ latex_pkg_list <- function() {
     "\\usepackage{threeparttable}",
     "\\usepackage{threeparttablex}",
     "\\usepackage[normalem]{ulem}",
-    "\\usepackage[normalem]{ulem}",
     "\\usepackage[utf8]{inputenc}",
     "\\usepackage{makecell}",
     "\\usepackage{xcolor}"


### PR DESCRIPTION
`\\usepackage[normalem]{ulem}` was listed twice.