### PR TITLE
Do not use HOLD position as float default, close #568

### DIFF
--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -547,7 +547,7 @@ styling_latex_position_center <- function(x, table_info, hold_position,
                 "\n\\end{", table.envir, "}")
     if (hold_position == "hold_position") {
       x <- styling_latex_hold_position(x)
-    } else {
+    } else if(hold_position == "HOLD_position") {
       x <- styling_latex_HOLD_position(x)
     }
   }


### PR DESCRIPTION
As reported in #568, kable_styling would put a strict float environment in cases where there was not a caption supplied. This appears to be caused by an over-agressive else statement in the centering function, which appears to be skipped when applying the caption.
