### PR TITLE
Force user-supplied strings to UTF-8 encoding

### DIFF
--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -279,7 +279,7 @@ column_spec_html_cell <- function(target_cell, width, width_min, width_max,
   }
   if (!is.null(extra_css)) {
     xml_attr(target_cell, "style") <- paste0(xml_attr(target_cell, "style"),
-                                             extra_css)
+                                             enc2utf8(extra_css))
   }
 
   if (!is.null(image) && (length(image) > 1 || !is.null(image[[1]]))) {
@@ -303,13 +303,13 @@ column_spec_html_cell <- function(target_cell, width, width_min, width_max,
   # favor popover over tooltip
   if (!is.null(popover)) {
     if (!inherits(popover, "ke_popover")) popover <- spec_popover(popover)
-    popover_list <- attr(popover, 'list')
+    popover_list <- lapply(attr(popover, 'list'), enc2utf8)
     for (p in names(popover_list)) {
       xml_attr(target_cell, p) <- popover_list[p]
     }
   } else if (!is.null(tooltip)) {
     if (!inherits(tooltip, "ke_tooltip")) tooltip <- spec_tooltip(tooltip)
-    tooltip_list <- attr(tooltip, 'list')
+    tooltip_list <- lapply(attr(tooltip, 'list'), enc2utf8)
     for (t in names(tooltip_list)) {
       xml_attr(target_cell, t) <- tooltip_list[t]
     }

--- a/R/row_spec.R
+++ b/R/row_spec.R
@@ -175,7 +175,7 @@ xml_cell_style <- function(x, bold, italic, monospace,
                                    "deg);")
   }
   if (!is.null(extra_css)) {
-    xml_attr(x, "style") <- paste0(xml_attr(x, "style"), extra_css)
+    xml_attr(x, "style") <- paste0(xml_attr(x, "style"), enc2utf8(extra_css))
   }
   return(x)
 }


### PR DESCRIPTION
In issue #583, the problem is that `xml2::xml_attr<-` wants the string value to be in UTF-8, and on Windows, the string was Latin1 encoded.  This PR forces user-supplied strings to be encoded in UTF-8 when set as XML attributes.  It fixes a test version of the file from that issue on my system. 