### PR TITLE
option to add_indent spacing to any column

### DIFF
--- a/R/add_indent.R
+++ b/R/add_indent.R
@@ -75,7 +75,9 @@ add_indent_latex <- function(kable_input, positions,
       }
     }
     new_rowtext <- paste(unlist(new_rowtext), collapse = " & ")
-    out <- sub(rowtext, new_rowtext, out, perl = TRUE)
+    out <- sub(paste0(rowtext, "(\\\\\\\\\\*?(\\[.*\\])?\n)"),
+               paste0(new_rowtext, "\\1"),
+               out, perl = TRUE)
     table_info$contents[i] <- new_rowtext
   }
   out <- structure(out, format = "latex", class = "knitr_kable")

--- a/R/add_indent.R
+++ b/R/add_indent.R
@@ -5,6 +5,7 @@
 #' be indented.
 #' @param level_of_indent a numeric value for the indent level. Default is 1.
 #' @param all_cols T/F whether to apply indentation to all columns
+#' @param target_cols A vector of numeric column positions. Default is 1.
 #'
 #' @examples
 #' \dontrun{
@@ -15,7 +16,8 @@
 #'
 #' @export
 add_indent <- function(kable_input, positions,
-                       level_of_indent = 1, all_cols = FALSE) {
+                       level_of_indent = 1, all_cols = FALSE,
+                       target_cols = 1) {
 
   if (!is.numeric(positions)) {
     stop("Positions can only take numeric row numbers (excluding header rows).")
@@ -28,16 +30,17 @@ add_indent <- function(kable_input, positions,
     return(kable_input)
   }
   if (kable_format == "html") {
-    return(add_indent_html(kable_input, positions, level_of_indent, all_cols))
+    return(add_indent_html(kable_input, positions, level_of_indent, all_cols, target_cols))
   }
   if (kable_format == "latex") {
-    return(add_indent_latex(kable_input, positions, level_of_indent, all_cols))
+    return(add_indent_latex(kable_input, positions, level_of_indent, all_cols, target_cols))
   }
 }
 
 # Add indentation for LaTeX
 add_indent_latex <- function(kable_input, positions,
-                             level_of_indent = 1, all_cols = FALSE) {
+                             level_of_indent = 1, all_cols = FALSE,
+                             target_cols = 1) {
   table_info <- magic_mirror(kable_input)
   out <- solve_enc(kable_input)
   level_of_indent<-as.numeric(level_of_indent)
@@ -57,18 +60,22 @@ add_indent_latex <- function(kable_input, positions,
 
   for (i in positions + table_info$position_offset) {
     rowtext <- table_info$contents[i]
+    new_rowtext <- unlist(latex_row_cells(rowtext))
     if (all_cols) {
-      new_rowtext <- latex_row_cells(rowtext)
       new_rowtext <- lapply(new_rowtext, function(x) {
         paste0("\\\\hspace\\{", level_of_indent ,"em\\}", x)
       })
       new_rowtext <- paste(unlist(new_rowtext), collapse = " & ")
     } else {
-      new_rowtext <- latex_indent_unit(rowtext, level_of_indent)
+      if (all(target_cols %in% seq_along(new_rowtext))) {
+        new_rowtext[target_cols] <- latex_indent_unit(new_rowtext[target_cols], level_of_indent)
+      } else {
+        stop("There aren't that many columns in the row. Check target_cols in ",
+         "add_indent_latex.")
+      }
     }
-    out <- sub(paste0(rowtext, "(\\\\\\\\\\*?(\\[.*\\])?\n)"),
-               paste0(new_rowtext, "\\1"),
-               out, perl = TRUE)
+    new_rowtext <- paste(unlist(new_rowtext), collapse = " & ")
+    out <- sub(rowtext, new_rowtext, out, perl = TRUE)
     table_info$contents[i] <- new_rowtext
   }
   out <- structure(out, format = "latex", class = "knitr_kable")
@@ -86,7 +93,8 @@ latex_indent_unit <- function(rowtext, level_of_indent) {
 
 # Add indentation for HTML
 add_indent_html <- function(kable_input, positions,
-                            level_of_indent = 1, all_cols = FALSE) {
+                            level_of_indent = 1, all_cols = FALSE,
+                            target_cols = 1) {
   kable_attrs <- attributes(kable_input)
 
   kable_xml <- kable_as_xml(kable_input)
@@ -102,8 +110,6 @@ add_indent_html <- function(kable_input, positions,
     row_to_edit = xml_children(kable_tbody)[[i]]
     if (all_cols) {
       target_cols = 1:xml2::xml_length(row_to_edit)
-    } else {
-      target_cols = 1
     }
 
     for (j in target_cols) {

--- a/man/add_indent.Rd
+++ b/man/add_indent.Rd
@@ -4,7 +4,13 @@
 \alias{add_indent}
 \title{Add indentations to row headers}
 \usage{
-add_indent(kable_input, positions, level_of_indent = 1, all_cols = FALSE)
+add_indent(
+  kable_input,
+  positions,
+  level_of_indent = 1,
+  all_cols = FALSE,
+  target_cols = 1
+)
 }
 \arguments{
 \item{kable_input}{Output of \code{knitr::kable()} with \code{format} specified}
@@ -15,6 +21,8 @@ be indented.}
 \item{level_of_indent}{a numeric value for the indent level. Default is 1.}
 
 \item{all_cols}{T/F whether to apply indentation to all columns}
+
+\item{target_cols}{A vector of numeric column positions. Default is 1.}
 }
 \description{
 Add indentations to row headers

--- a/tests/testthat/test-indent-html.R
+++ b/tests/testthat/test-indent-html.R
@@ -1,0 +1,39 @@
+context("add_indent")
+
+test_that("add_indent can add to 1 row", {
+  observed <- kable(mtcars[1:4, 1:3], "html") %>%
+    add_indent(1) %>%
+    as.character()
+  expected <- "<table>\n <thead>\n  <tr>\n   <th style=\"text-align:left;\">   </th>\n   <th style=\"text-align:right;\"> mpg </th>\n   <th style=\"text-align:right;\"> cyl </th>\n   <th style=\"text-align:right;\"> disp </th>\n  </tr>\n </thead>\n<tbody>\n  <tr>\n   <td style=\"text-align:left;padding-left: 2em;\" indentlevel=\"1\"> Mazda RX4 </td>\n   <td style=\"text-align:right;\"> 21.0 </td>\n   <td style=\"text-align:right;\"> 6 </td>\n   <td style=\"text-align:right;\"> 160 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;\"> Mazda RX4 Wag </td>\n   <td style=\"text-align:right;\"> 21.0 </td>\n   <td style=\"text-align:right;\"> 6 </td>\n   <td style=\"text-align:right;\"> 160 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;\"> Datsun 710 </td>\n   <td style=\"text-align:right;\"> 22.8 </td>\n   <td style=\"text-align:right;\"> 4 </td>\n   <td style=\"text-align:right;\"> 108 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;\"> Hornet 4 Drive </td>\n   <td style=\"text-align:right;\"> 21.4 </td>\n   <td style=\"text-align:right;\"> 6 </td>\n   <td style=\"text-align:right;\"> 258 </td>\n  </tr>\n</tbody>\n</table>"
+  expect_equal(observed, expected)
+})
+
+test_that("add_indent can be added multiple times.", {
+  observed <- kable(mtcars[1:4, 1:3], "html") %>%
+    add_indent(1:3) %>%
+    add_indent(1) %>%
+    as.character()
+  expected <- "<table>\n <thead>\n  <tr>\n   <th style=\"text-align:left;\">   </th>\n   <th style=\"text-align:right;\"> mpg </th>\n   <th style=\"text-align:right;\"> cyl </th>\n   <th style=\"text-align:right;\"> disp </th>\n  </tr>\n </thead>\n<tbody>\n  <tr>\n   <td style=\"text-align:left;padding-left: 4em;\" indentlevel=\"2\"> Mazda RX4 </td>\n   <td style=\"text-align:right;\"> 21.0 </td>\n   <td style=\"text-align:right;\"> 6 </td>\n   <td style=\"text-align:right;\"> 160 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;padding-left: 2em;\" indentlevel=\"1\"> Mazda RX4 Wag </td>\n   <td style=\"text-align:right;\"> 21.0 </td>\n   <td style=\"text-align:right;\"> 6 </td>\n   <td style=\"text-align:right;\"> 160 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;padding-left: 2em;\" indentlevel=\"1\"> Datsun 710 </td>\n   <td style=\"text-align:right;\"> 22.8 </td>\n   <td style=\"text-align:right;\"> 4 </td>\n   <td style=\"text-align:right;\"> 108 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;\"> Hornet 4 Drive </td>\n   <td style=\"text-align:right;\"> 21.4 </td>\n   <td style=\"text-align:right;\"> 6 </td>\n   <td style=\"text-align:right;\"> 258 </td>\n  </tr>\n</tbody>\n</table>"
+  expect_equal(observed, expected)
+})
+
+test_that("add_indent can add to an interior column.", {
+  cars <- mtcars[1:4, 1:3]
+  cars$cyl <- as.character(cars$cyl)
+  observed <- kable(cars, "html") %>%
+    add_indent(1:3, target_cols = 3) %>%
+    as.character()
+  expected <- "<table>\n <thead>\n  <tr>\n   <th style=\"text-align:left;\">   </th>\n   <th style=\"text-align:right;\"> mpg </th>\n   <th style=\"text-align:left;\"> cyl </th>\n   <th style=\"text-align:right;\"> disp </th>\n  </tr>\n </thead>\n<tbody>\n  <tr>\n   <td style=\"text-align:left;\"> Mazda RX4 </td>\n   <td style=\"text-align:right;\"> 21.0 </td>\n   <td style=\"text-align:left;padding-left: 2em;\" indentlevel=\"1\"> 6 </td>\n   <td style=\"text-align:right;\"> 160 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;\"> Mazda RX4 Wag </td>\n   <td style=\"text-align:right;\"> 21.0 </td>\n   <td style=\"text-align:left;padding-left: 2em;\" indentlevel=\"1\"> 6 </td>\n   <td style=\"text-align:right;\"> 160 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;\"> Datsun 710 </td>\n   <td style=\"text-align:right;\"> 22.8 </td>\n   <td style=\"text-align:left;padding-left: 2em;\" indentlevel=\"1\"> 4 </td>\n   <td style=\"text-align:right;\"> 108 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;\"> Hornet 4 Drive </td>\n   <td style=\"text-align:right;\"> 21.4 </td>\n   <td style=\"text-align:left;\"> 6 </td>\n   <td style=\"text-align:right;\"> 258 </td>\n  </tr>\n</tbody>\n</table>"
+  expect_equal(observed, expected)
+})
+
+test_that("add_indent can add to an interior column multiple times.", {
+  cars <- mtcars[1:4, 1:3]
+  cars$cyl <- as.character(cars$cyl)
+  observed <- kable(cars, "html") %>%
+    add_indent(1:3, target_cols = 3) %>%
+    add_indent(1, target_cols = 3) %>%
+    as.character()
+  expected <- "<table>\n <thead>\n  <tr>\n   <th style=\"text-align:left;\">   </th>\n   <th style=\"text-align:right;\"> mpg </th>\n   <th style=\"text-align:left;\"> cyl </th>\n   <th style=\"text-align:right;\"> disp </th>\n  </tr>\n </thead>\n<tbody>\n  <tr>\n   <td style=\"text-align:left;\"> Mazda RX4 </td>\n   <td style=\"text-align:right;\"> 21.0 </td>\n   <td style=\"text-align:left;padding-left: 4em;\" indentlevel=\"2\"> 6 </td>\n   <td style=\"text-align:right;\"> 160 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;\"> Mazda RX4 Wag </td>\n   <td style=\"text-align:right;\"> 21.0 </td>\n   <td style=\"text-align:left;padding-left: 2em;\" indentlevel=\"1\"> 6 </td>\n   <td style=\"text-align:right;\"> 160 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;\"> Datsun 710 </td>\n   <td style=\"text-align:right;\"> 22.8 </td>\n   <td style=\"text-align:left;padding-left: 2em;\" indentlevel=\"1\"> 4 </td>\n   <td style=\"text-align:right;\"> 108 </td>\n  </tr>\n  <tr>\n   <td style=\"text-align:left;\"> Hornet 4 Drive </td>\n   <td style=\"text-align:right;\"> 21.4 </td>\n   <td style=\"text-align:left;\"> 6 </td>\n   <td style=\"text-align:right;\"> 258 </td>\n  </tr>\n</tbody>\n</table>"
+  expect_equal(observed, expected)
+})

--- a/tests/testthat/test-indent-latex.R
+++ b/tests/testthat/test-indent-latex.R
@@ -17,4 +17,19 @@ test_that("add_indent can be added multiple times.", {
   expect_equal(observed, expected)
 })
 
+test_that("add_indent can add to an interior column.", {
+  observed <- kable(mtcars[1:4, 1:3], "latex") %>%
+    add_indent(1:3, target_cols = 2) %>%
+    as.character()
+  expected <- "\n\\begin{tabular}{l|r|r|r}\n\\hline\n  & mpg & cyl & disp\\\\\n\\hline\nMazda RX4 & \\hspace{1em}21.0 & 6 & 160\\\\\n\\hline\nMazda RX4 Wag & \\hspace{1em}21.0 & 6 & 160\\\\\n\\hline\nDatsun 710 & \\hspace{1em}22.8 & 4 & 108\\\\\n\\hline\nHornet 4 Drive & 21.4 & 6 & 258\\\\\n\\hline\n\\end{tabular}"
+  expect_equal(observed, expected)
+})
 
+test_that("add_indent can add to an interior column multiple times.", {
+  observed <- kable(mtcars[1:4, 1:3], "latex") %>%
+    add_indent(1:3, target_cols = 2) %>%
+    add_indent(1, target_cols = 2) %>%
+    as.character()
+  expected <- "\n\\begin{tabular}{l|r|r|r}\n\\hline\n  & mpg & cyl & disp\\\\\n\\hline\nMazda RX4 & \\hspace{1em}\\hspace{1em}21.0 & 6 & 160\\\\\n\\hline\nMazda RX4 Wag & \\hspace{1em}21.0 & 6 & 160\\\\\n\\hline\nDatsun 710 & \\hspace{1em}22.8 & 4 & 108\\\\\n\\hline\nHornet 4 Drive & 21.4 & 6 & 258\\\\\n\\hline\n\\end{tabular}"
+  expect_equal(observed, expected)
+})


### PR DESCRIPTION
Currently `add_indent` inserts spacing into the leftmost column only. I'd like to propose making it possible to specify which column is indented. This pull request has a potential implementation with some basic tests.

Example use case. The tables I would like to create include a line number in the leftmost column, with labels for each row in the second column.  Each row presents a different total or subtotal. Indentation helps make the calculations more evident to the reader. 

* Total = Subtotal A + Subtotal B
* Subtotal A = Item A1 + Item A2
* Subtotal B = Item B1 + Item B2

Without indentation it might look like this
```r
amounts %>% 
    kable() 
```

| Line Number | Stub Label |  Amount |
|---:|:----------------|----: |
|  1| Total | 10 |
|  2| Subtotal A | 8 | 
|  3| Item A1 | 5 | 
|  4| Item A2 | 3 | 
|  5| Subtotal B | 2 |
|  6| Item B1 | 3 | 
|  7| Item B2 | -1 | 

With indentation it might look like this
```r
amounts %>% 
    kable() %>%
    add_indent(positions = c(2, 7), level_of_indent = 1, target_cols = 2) %>%
    add_indent(positions = c(3, 4, 6, 7), level_of_indent = 2, target_cols = 2)
```

| Line Number | Stub Label |  Amount |
|---:|:----------------|----: |
|  1| Total | 10 |
|  2| ___Subtotal A | 8 | 
|  3| ______Item A1 | 5 | 
|  4| ______Item A2 | 3 | 
|  5| ___Subtotal B | 2 |
|  6| ______Item B1 | 3 | 
|  7| ______Item B2 | -1 | 

