### PR TITLE
Update save_kable.R to include MathJax

### DIFF
--- a/R/save_kable.R
+++ b/R/save_kable.R
@@ -84,8 +84,7 @@ save_kable_html <- function(x, file, bs_theme, self_contained,
 
   html_header <- htmltools::tags$head(dependencies)
   html_table <- htmltools::HTML(as.character(x),
-        '<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [["$","$"]]}})</script><script type="text/javascript" async
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"></script>')
+        '<script type="text/x-mathjax-config">MathJax.Hub.Config({tex2jax: {inlineMath: [["$","$"]]}})</script><script async src="https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>')
   html_result <- htmltools::tagList(html_header, html_table)
 
   # Check if we are generating an image and use webshot to do that


### PR DESCRIPTION
Fix for #578?

This commit makes the HTML table `save_kable_html()` function mirror this:

https://github.com/haozhu233/kableExtra/blob/4c93f1afc26efcd04fa729cb4a522d5f262bb6bd/R/print.R#L12-L15

Otherwise, MathJax is not included in the HTML file (which affects the image outputs).