### PR TITLE
Allow arbitrary palette in `spec_color`.

### DIFF
--- a/R/spec_tools.R
+++ b/R/spec_tools.R
@@ -1,22 +1,27 @@
-#' Generate viridis Color code for continuous values
+#' Generate viridis or other color code for continuous values
 #'
 #' @inheritParams viridisLite::viridis
 #' @param x continuous vectors of values
 #' @param na_color color code for NA values
 #' @param scale_from input range (vector of length two). If not given,
 #' is calculated from the range of x
+#' @param palette The palette to use as a character vector of colors.  If
+#' this is specified, parameters other than `x`, `na_color` and `scale_from`
+#' are ignored.
 #' @export
 spec_color <- function(x, alpha = 1, begin = 0, end = 1,
                        direction = 1, option = "D",
-                       na_color = "#BBBBBB", scale_from = NULL) {
+                       na_color = "#BBBBBB", scale_from = NULL,
+                       palette = viridisLite::viridis(256, alpha, begin, end, direction, option)) {
+  n <- length(palette)
   if (is.null(scale_from)) {
-    x <- round(rescale(x, c(1, 256)))
+    x <- round(rescale(x, c(1, n)))
   } else {
-    x <- round(rescale(x, to = c(1, 256),
+    x <- round(rescale(x, to = c(1, n),
                        from = scale_from))
   }
 
-  color_code <- viridisLite::viridis(256, alpha, begin, end, direction, option)[x]
+  color_code <- palette[x]
   color_code[is.na(color_code)] <- na_color
   return(color_code)
 }

--- a/man/spec_color.Rd
+++ b/man/spec_color.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/spec_tools.R
 \name{spec_color}
 \alias{spec_color}
-\title{Generate viridis Color code for continuous values}
+\title{Generate viridis or other color code for continuous values}
 \usage{
 spec_color(
   x,
@@ -12,7 +12,8 @@ spec_color(
   direction = 1,
   option = "D",
   na_color = "#BBBBBB",
-  scale_from = NULL
+  scale_from = NULL,
+  palette = viridisLite::viridis(256, alpha, begin, end, direction, option)
 )
 }
 \arguments{
@@ -46,7 +47,11 @@ Eight options are available:
 
 \item{scale_from}{input range (vector of length two). If not given,
 is calculated from the range of x}
+
+\item{palette}{The palette to use as a character vector of colors.  If
+this is specified, parameters other than \code{x}, \code{na_color} and \code{scale_from}
+are ignored.}
 }
 \description{
-Generate viridis Color code for continuous values
+Generate viridis or other color code for continuous values
 }

--- a/vignettes/awesome_table_in_html.Rmd
+++ b/vignettes/awesome_table_in_html.Rmd
@@ -342,7 +342,7 @@ kbl(cs_dt, escape = F) %>%
 ```
 
 ## Visualize data with Viridis Color
-This package also comes with a few helper functions, including `spec_color`, `spec_font_size` & `spec_angle`. These functions can rescale continuous variables to certain scales. For example, function `spec_color` would map a continuous variable to any [viridis color palettes](https://CRAN.R-project.org/package=viridisLite). It offers a very visually impressive representation in a tabular format. 
+This package also comes with a few helper functions, including `spec_color`, `spec_font_size` & `spec_angle`. These functions can rescale continuous variables to certain scales. For example, function `spec_color` would map a continuous variable to any color palettes, by default [viridis palettes](https://CRAN.R-project.org/package=viridisLite). It offers a very visually impressive representation in a tabular format. 
 
 ```{r}
 vs_dt <- iris[1:10, ]


### PR DESCRIPTION
This StackOverflow question https://stackoverflow.com/q/70639647/2554330 wanted to use a non-Viridis palette in `spec_color`.  This PR adds that as a possibility by adding a `palette` argument to the function.