### PR TITLE
Handle kable object that includes extra stuff

### DIFF
--- a/R/kableExtra-package.R
+++ b/R/kableExtra-package.R
@@ -58,7 +58,7 @@
 #' @importFrom stringr fixed str_count str_split str_match str_detect str_match_all
 #' str_extract str_replace_all str_trim str_extract_all str_sub str_replace
 #' @importFrom xml2 read_xml xml_attr xml_has_attr xml_attr<- read_html
-#' xml_child xml_children xml_name xml_add_sibling xml_add_child xml_text
+#' xml_child xml_children xml_name xml_add_sibling xml_add_child xml_text xml_length
 #' xml_remove write_xml xml_text<- xml_length
 #' @importFrom rvest html_table
 #' @importFrom knitr knit_meta_add include_graphics knit_print asis_output kable

--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -214,7 +214,8 @@ htmlTable_styling <- function(kable_input,
   }
   kable_attrs <- attributes(kable_input)
   kable_xml <- read_kable_as_xml(kable_input)
-
+  pre <- attr(kable_xml, "pre")
+  post <- attr(kable_xml, "post")
   # Modify class
   bootstrap_options <- match.arg(
     bootstrap_options,
@@ -296,7 +297,7 @@ htmlTable_styling <- function(kable_input,
     }
   }
 
-  out <- as_kable_xml(kable_xml)
+  out <- as_kable_xml(kable_xml, pre, post)
   if (protect_latex) {
     out <- replace_latex_in_kable(out, kable_attrs$extracted_latex)
     kable_attrs$extracted_latex <- NULL


### PR DESCRIPTION
My `tables` package has a `toKable` function so that it can produce 
output to be modified by `kableExtra`.  I just noticed that it isn't 
working any more, and I've narrowed down the issue to the following kind 
of example:
```r
  tables::table_options(doCSS = TRUE)
  tab <- tables::tabular(mpg ~ mean, data = mtcars)
  kab <- tables::toKable(tab, format = "html")
  cat(as.character(kab))
#> <style>
#> .Rtable thead, .Rtable .even {
#>   background-color: inherit;
#> }
#> .left   { text-align:left; }
#> .center { text-align:center; }
#> .right  { text-align:right; }
#> .Rtable, .Rtable thead {
#>   border-collapse: collapse;
#>   border-style: solid;
#>   border-width: medium 0;
#>   border-color: inherit;
#> }
#> .Rtable th, .Rtable td {
#>   padding-left: 0.5em;
#>   padding-right: 0.5em;
#>   border-width: 0;
#> }
#> </style>
#>  <table class="Rtable">
#>  <thead>
#>  <tr class="center">
#>   <th></th>
#>   <th>mean</th>
#> </tr>
#>  </thead>
#>  <tbody>
#>  <tr class="center">
#>   <th class="left">mpg</th>
#>   <td>20.09</td>
#> </tr>
#>  </tbody>
#>  </table>
  kab2 <- kab |> kableExtra::kable_styling(full_width = FALSE)
  cat(as.character(kab2))
#> <style class="table" style="width: auto !important; margin-left: 
auto; margin-right: auto;">
#> .Rtable thead, .Rtable .even {
#>   background-color: inherit;
#> }
#> .left   { text-align:left; }
#> .center { text-align:center; }
#> .right  { text-align:right; }
#> .Rtable, .Rtable thead {
#>   border-collapse: collapse;
#>   border-style: solid;
#>   border-width: medium 0;
#>   border-color: inherit;
#> }
#> .Rtable th, .Rtable td {
#>   padding-left: 0.5em;
#>   padding-right: 0.5em;
#>   border-width: 0;
#> }
#> </style>
```
If you look at the HTML code in `kab`, it's a `<style> ... </style>` block 
followed by a `<table> ... </table>` block, but in `kab2`, the table is dropped.  This happens when `htmlTable_styling` converts its input to XML:  it assumes that the input is always just one block containing the table.

The current PR drops this assumption.  It looks through the XML for the first table, and just copies everything earlier or later into the final `htmlTable_styling` output.