### PR TITLE
Fixed a bug in current column_spec

### DIFF
--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -400,7 +400,7 @@ column_spec_latex <- function(kable_input, column, width,
   }
 
   # issue #658: offset generates bad indices with single row tables
-  rows <- intersect(rows, seq_along(nrows))
+  rows <- intersect(rows, seq(nrows))
 
   for (i in rows) {
     target_row <- table_info$contents[i]


### PR DESCRIPTION
While reviewing #790, I noticed a bug in column_spec introduced with recent changes. 

Right now, 

```
library(kableExtra)

kbl(mtcars[1:2, 1:2], format = "latex", booktabs=T) |>
    column_spec(1, bold=T) |>
  cat()
```
gives

```
\begin{tabular}[t]{>{}lrr}
\toprule
  & mpg & cyl\\
\midrule
Mazda RX4 & 21 & 6\\
Mazda RX4 Wag & 21 & 6\\
\bottomrule
\end{tabular}
```

Apparently, it's related to this change. https://github.com/haozhu233/kableExtra/blob/d3e7953179b8b8ac385213175ea01f4668b5bbd3/R/column_spec.R#L403. In this PR, I changed it from `seq_along` to `seq`. @vincentarelbundock Could you check if this is what's expected?