### PR TITLE
[WIP] Rows are not regexes --- LaTeX only

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Suggests:
     formattable,
     sparkline,
     webshot2
+Config/testthat/edition: 3
 VignetteBuilder: knitr
 Encoding: UTF-8
 RoxygenNote: 7.2.3

--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -312,7 +312,7 @@ pdfTable_add_header_above <- function(kable_input, header, bold, italic,
 
   align <- vapply(align, match.arg, 'a', choices = c("l", "c", "r"))
 
-  hline_type <- switch(table_info$booktabs + 1, "\\\\hline", "\\\\toprule")
+  hline_type <- switch(table_info$booktabs + 1, "\\hline", "\\toprule")
   new_header_split <- pdfTable_new_header_generator(
     header, table_info$booktabs, bold, italic, monospace, underline, strikeout,
     align, color, background, font_size, angle, line_sep,
@@ -373,32 +373,32 @@ pdfTable_new_header_generator <- function(header_df, booktabs = FALSE,
   header <- header_df$header
   colspan <- header_df$colspan
 
-  header <- ifelse(bold, paste0('\\\\textbf\\{', header, '\\}'), header)
-  header <- ifelse(italic, paste0('\\\\em\\{', header, '\\}'), header)
-  header <- ifelse(monospace, paste0('\\\\ttfamily\\{', header, '\\}'), header)
-  header <- ifelse(underline, paste0('\\\\underline\\{', header, '\\}'), header)
-  header <- ifelse(strikeout, paste0('\\\\sout\\{', header, '\\}'), header)
+  header <- ifelse(bold, paste0('\\textbf{', header, '}'), header)
+  header <- ifelse(italic, paste0('\\em\\{', header, '}'), header)
+  header <- ifelse(monospace, paste0('\\ttfamily{', header, '}'), header)
+  header <- ifelse(underline, paste0('\\underline{', header, '}'), header)
+  header <- ifelse(strikeout, paste0('\\sout{', header, '}'), header)
   if (!is.null(color)) {
-    color <- latex_color(color)
-    header <- paste0("\\\\textcolor", color, "\\{", header, "\\}")
+    color <- latex_color__(color)
+    header <- paste0("\\textcolor", color, "{", header, "}")
   }
   if (!is.null(background)) {
-    background <- latex_color(background)
-    header <- paste0("\\\\cellcolor", background, "\\{", header, "\\}")
+    background <- latex_color__(background)
+    header <- paste0("\\cellcolor", background, "{", header, "}")
   }
   if (!is.null(font_size)) {
-    header <- paste0("\\\\bgroup\\\\fontsize\\{", font_size, "\\}\\{",
+    header <- paste0("\\bgroup\\fontsize{", font_size, "}{",
                      as.numeric(font_size) + 2,
-                     "\\}\\\\selectfont ", header, "\\\\egroup\\{\\}")
+                     "}\\selectfont ", header, "\\egroup{}")
   }
   if (!is.null(angle)) {
-    header <- paste0("\\\\rotatebox\\{", angle, "\\}\\{", header, "\\}")
+    header <- paste0("\\rotatebox{", angle, "}{", header, "}")
   }
   header_items <- paste0(
-    '\\\\multicolumn\\{', colspan, '\\}\\{', align, '\\}\\{', header, '\\}'
+    '\\multicolumn{', colspan, '}{', align, '}{', header, '}'
   )
 
-  header_text <- paste(paste(header_items, collapse = " & "), "\\\\\\\\")
+  header_text <- paste(paste(header_items, collapse = " & "), "\\\\")
   cline <- cline_gen(header_df, booktabs, line_sep)
   return(c(header_text, cline))
 }
@@ -409,8 +409,8 @@ cline_gen <- function(header_df, booktabs, line_sep) {
   cline_start <- cline_start[-length(cline_start)]
   cline_type <- switch(
     booktabs + 1,
-    "\\\\cline{",
-    paste0("\\\\cmidrule(l{", line_sep, "pt}r{", line_sep, "pt}){"))
+    "\\cline{",
+    paste0("\\cmidrule(l{", line_sep, "pt}r{", line_sep, "pt}){"))
   cline <- paste0(cline_type, cline_start, "-", cline_end, "}")
   cline <- cline[trimws(header_df$header) != ""]
   cline <- paste(cline, collapse = " ")

--- a/R/cell_spec.R
+++ b/R/cell_spec.R
@@ -173,11 +173,11 @@ cell_spec_latex <- function(x, bold, italic, monospace, underline, strikeout,
   x <- sprintf(ifelse(underline, "\\underline{%s}", "%s"), x)
   x <- sprintf(ifelse(strikeout, "\\sout{%s}", "%s"), x)
   if (!is.null(color)) {
-    color <- latex_color(color, escape = FALSE)
+    color <- latex_color(color)
     x <- paste0("\\textcolor", color, "{", x, "}")
   }
   if (!is.null(background)) {
-    background <- latex_color(background, escape = FALSE)
+    background <- latex_color(background)
     background_env <- ifelse(latex_background_in_cell, "cellcolor", "colorbox")
     x <- paste0("\\", background_env, background, "{", x, "}")
   }

--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -346,7 +346,7 @@ column_spec_latex <- function(kable_input, column, width,
             " especially in LaTeX, to get a desired result. ")
   }
   align_collapse <- ifelse(table_info$booktabs | !is.null(table_info$xtable),
-                           "", "\\|")
+                           "", "|")
   kable_align_old <- paste(table_info$align_vector, collapse = align_collapse)
 
   table_info$align_vector[column] <- unlist(lapply(
@@ -535,7 +535,7 @@ latex_cell_builder <- function(target_row, column, table_info,
     new_row[column] <- paste0("\\ttfamily{", new_row[column], "}")
   }
   if (underline) {
-    new_row[column] <- paste0("\\underline\\{", new_row[column], "}")
+    new_row[column] <- paste0("\\underline{", new_row[column], "}")
   }
   if (strikeout) {
     new_row[column] <- paste0("\\sout{", new_row[column], "}")

--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -359,10 +359,10 @@ column_spec_latex <- function(kable_input, column, width,
 
   kable_align_new <- paste(table_info$align_vector, collapse = align_collapse)
 
-  out <- sub(paste0("\\{", kable_align_old, "\\}"),
-             paste0("\\{", kable_align_new, "\\}"),
+  out <- sub(paste0("{", kable_align_old, "}"),
+             paste0("{", kable_align_new, "}"),
              solve_enc(kable_input),
-             perl = T)
+             fixed = TRUE)
 
   if (!is.null(width)) {
     fix_newline <- replace_makecell_with_newline(out, table_info, column)
@@ -413,7 +413,7 @@ column_spec_latex <- function(kable_input, column, width,
     temp_sub <- ifelse(i == 1 & (table_info$tabular == "longtable" |
                                    !is.null(table_info$repeat_header_latex)),
                        gsub, sub)
-    out <- temp_sub(target_row, new_row, out, perl = T)
+    out <- temp_sub(target_row, new_row, out, fixed = TRUE)
     table_info$contents[i] <- new_row
   }
 
@@ -453,10 +453,10 @@ latex_column_align_builder <- function(x, width,
   extra_align <- ""
   if (!is.null(width)) {
     extra_align <- switch(x,
-                          "l" = "\\\\raggedright\\\\arraybackslash",
-                          "c" = "\\\\centering\\\\arraybackslash",
-                          "r" = "\\\\raggedleft\\\\arraybackslash")
-    x <- paste0(latex_valign, "\\{", width, "\\}")
+                          "l" = "\\raggedright\\arraybackslash",
+                          "c" = "\\centering\\arraybackslash",
+                          "r" = "\\raggedleft\\arraybackslash")
+    x <- paste0(latex_valign, "{", width, "}")
   }
   # if (!is.null(color)) {
   #   color <- paste0("\\\\leavevmode\\\\color", latex_color(color))
@@ -471,13 +471,13 @@ latex_column_align_builder <- function(x, width,
   #                            c(bold, italic, monospace, underline, strikeout)]
   # latex_array_options <- c(latex_array_options, extra_align,
   #                          color, background)
-  latex_array_options <- paste0("\\>\\{", extra_align, "\\}")
+  latex_array_options <- paste0(">{", extra_align, "}")
   x <- paste0(latex_array_options, x)
   if (border_left) {
-    x <- paste0("\\|", x)
+    x <- paste0("|", x)
   }
   if (border_right) {
-    x <- paste0(x, "\\|")
+    x <- paste0(x, "|")
   }
   if (!is.null(latex_column_spec))
     x <- latex_column_spec
@@ -511,7 +511,7 @@ replace_makecell_with_newline <- function(kable_input, table_info, column) {
   new_contents <- unlist(lapply(contents_table, paste, collapse = " & "))
   for (i in rows_to_replace) {
     kable_input <- sub(table_info$contents[i], new_contents[i], kable_input,
-                       perl = T)
+                       fixed = TRUE)
     table_info$contents[i] <- new_contents[i]
   }
 
@@ -526,24 +526,23 @@ latex_cell_builder <- function(target_row, column, table_info,
                                ) {
   new_row <- latex_row_cells(target_row)[[1]]
   if (bold) {
-    new_row[column] <- paste0("\\\\textbf\\{", new_row[column], "\\}")
+    new_row[column] <- paste0("\\textbf{", new_row[column], "}")
   }
   if (italic) {
-    new_row[column] <- paste0("\\\\em\\{", new_row[column], "\\}")
+    new_row[column] <- paste0("\\em{", new_row[column], "}")
   }
   if (monospace) {
-    new_row[column] <- paste0("\\\\ttfamily\\{", new_row[column], "\\}")
+    new_row[column] <- paste0("\\ttfamily{", new_row[column], "}")
   }
   if (underline) {
-    new_row[column] <- paste0("\\\\underline\\{", new_row[column], "\\}")
+    new_row[column] <- paste0("\\underline\\{", new_row[column], "}")
   }
   if (strikeout) {
-    new_row[column] <- paste0("\\\\sout\\{", new_row[column], "\\}")
+    new_row[column] <- paste0("\\sout{", new_row[column], "}")
   }
   if (!is.null(color)) {
     clean_columns <- unlist(lapply(new_row[column], clear_color_latex))
-    new_row[column] <- paste0("\\\\textcolor", latex_color(color), "\\{",
-                              clean_columns, "\\}")
+    new_row[column] <- paste0("\\textcolor", latex_color(color), "{", clean_columns, "}")
   }
   # if (!is.null(font_size)) {
   #   new_row[column] <- paste0("\\\\begingroup\\\\fontsize\\{", font_size, "\\}\\{",
@@ -556,13 +555,13 @@ latex_cell_builder <- function(target_row, column, table_info,
   # }
   if (!is.null(background)) {
     clean_columns <- unlist(lapply(new_row[column], clear_color_latex, TRUE))
-    new_row[column] <- paste0("\\\\cellcolor", latex_color(background), "\\{",
-                              clean_columns, "\\}")
+    new_row[column] <- paste0("\\cellcolor", latex_color(background), "{",
+                              clean_columns, "}")
   }
 
   if (!is.null(link)) {
-    new_row[column] <- paste0("\\\\href\\{", escape_latex(link), "\\}\\{",
-                              new_row[column], "\\}")
+    new_row[column] <- paste0("\\href{", escape_latex(link), "}{",
+                              new_row[column], "}")
   }
 
   if (!is.null(image) && (length(image) > 1 || !is.null(image[[1]]))) {
@@ -570,10 +569,10 @@ latex_cell_builder <- function(target_row, column, table_info,
     if (inherits(image, "kableExtraInlinePlots")) {
       new_row[column] <- paste0(
         new_row[column],
-        '\\\\includegraphics\\[width=',
+        '\\includegraphics[width=',
         # '\\\\raisebox\\{-\\\\totalheight\\}\\{\\\\includegraphics\\[width=',
         round(image$width / image$res, 2), 'in, height=',
-        round(image$height / image$res, 2), 'in\\]\\{',
+        round(image$height / image$res, 2), 'in]{',
         image$path,
         '\\}'
         # '\\}\\}'
@@ -582,8 +581,8 @@ latex_cell_builder <- function(target_row, column, table_info,
       if (!is.null(image) && !is.na(image) && image != "") {
         new_row[column] <- paste0(
           new_row[column],
-          '\\\\includegraphics\\{',
-          image, '\\}'
+          '\\includegraphics{',
+          image, '}'
         )
       }
     }
@@ -593,3 +592,4 @@ latex_cell_builder <- function(target_row, column, table_info,
 
   return(new_row)
 }
+

--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -459,11 +459,11 @@ latex_column_align_builder <- function(x, width,
     x <- paste0(latex_valign, "{", width, "}")
   }
   # if (!is.null(color)) {
-  #   color <- paste0("\\\\leavevmode\\\\color", latex_color(color))
+  #   color <- paste0("\\\\leavevmode\\\\color", latex_color__(color))
   # }
   #
   # if (!is.null(background)) {
-  #   background <- paste0("\\\\columncolor", latex_color(background))
+  #   background <- paste0("\\\\columncolor", latex_color__(background))
   # }
   #
   # latex_array_options <- c("\\\\bfseries", "\\\\em", "\\\\ttfamily",
@@ -542,7 +542,7 @@ latex_cell_builder <- function(target_row, column, table_info,
   }
   if (!is.null(color)) {
     clean_columns <- unlist(lapply(new_row[column], clear_color_latex))
-    new_row[column] <- paste0("\\textcolor", latex_color(color), "{", clean_columns, "}")
+    new_row[column] <- paste0("\\textcolor", latex_color__(color), "{", clean_columns, "}")
   }
   # if (!is.null(font_size)) {
   #   new_row[column] <- paste0("\\\\begingroup\\\\fontsize\\{", font_size, "\\}\\{",
@@ -555,7 +555,7 @@ latex_cell_builder <- function(target_row, column, table_info,
   # }
   if (!is.null(background)) {
     clean_columns <- unlist(lapply(new_row[column], clear_color_latex, TRUE))
-    new_row[column] <- paste0("\\cellcolor", latex_color(background), "{",
+    new_row[column] <- paste0("\\cellcolor", latex_color__(background), "{",
                               clean_columns, "}")
   }
 
@@ -574,7 +574,7 @@ latex_cell_builder <- function(target_row, column, table_info,
         round(image$width / image$res, 2), 'in, height=',
         round(image$height / image$res, 2), 'in]{',
         image$path,
-        '\\}'
+        '}'
         # '\\}\\}'
         )
     } else {

--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -346,7 +346,7 @@ column_spec_latex <- function(kable_input, column, width,
             " especially in LaTeX, to get a desired result. ")
   }
   align_collapse <- ifelse(table_info$booktabs | !is.null(table_info$xtable),
-                           "", "|")
+                           "", "\\|")
   kable_align_old <- paste(table_info$align_vector, collapse = align_collapse)
 
   table_info$align_vector[column] <- unlist(lapply(
@@ -357,12 +357,13 @@ column_spec_latex <- function(kable_input, column, width,
     }
   ))
 
+
   kable_align_new <- paste(table_info$align_vector, collapse = align_collapse)
 
   out <- sub(paste0("{", kable_align_old, "}"),
              paste0("{", kable_align_new, "}"),
              solve_enc(kable_input),
-             fixed = TRUE)
+             perl = TRUE)
 
   if (!is.null(width)) {
     fix_newline <- replace_makecell_with_newline(out, table_info, column)
@@ -453,9 +454,9 @@ latex_column_align_builder <- function(x, width,
   extra_align <- ""
   if (!is.null(width)) {
     extra_align <- switch(x,
-                          "l" = "\\raggedright\\arraybackslash",
-                          "c" = "\\centering\\arraybackslash",
-                          "r" = "\\raggedleft\\arraybackslash")
+                          "l" = "\\\\raggedright\\\\arraybackslash",
+                          "c" = "\\\\centering\\\\arraybackslash",
+                          "r" = "\\\\raggedleft\\\\arraybackslash")
     x <- paste0(latex_valign, "{", width, "}")
   }
   # if (!is.null(color)) {
@@ -471,7 +472,7 @@ latex_column_align_builder <- function(x, width,
   #                            c(bold, italic, monospace, underline, strikeout)]
   # latex_array_options <- c(latex_array_options, extra_align,
   #                          color, background)
-  latex_array_options <- paste0(">{", extra_align, "}")
+  latex_array_options <- paste0(">\\{", extra_align, "\\}")
   x <- paste0(latex_array_options, x)
   if (border_left) {
     x <- paste0("|", x)

--- a/R/group_rows.R
+++ b/R/group_rows.R
@@ -245,54 +245,54 @@ group_rows_latex <- function(kable_input, group_label, start_row, end_row,
   }
 
   if (bold) {
-    group_label <- paste0("\\\\textbf{", group_label, "}")
+    group_label <- paste0("\\textbf{", group_label, "}")
   }
 
-  if (italic) group_label <- paste0("\\\\textit{", group_label, "}")
+  if (italic) group_label <- paste0("\\textit{", group_label, "}")
 
   if (monospace) {
-    group_label <- paste0("\\\\ttfamily\\{", group_label, "\\}")
+    group_label <- paste0("\\ttfamily{", group_label, "}")
   }
   if (underline) {
-    group_label <- paste0("\\\\underline\\{", group_label, "\\}")
+    group_label <- paste0("\\underline{", group_label, "}")
   }
   if (strikeout) {
-    group_label <- paste0("\\\\sout\\{", group_label, "\\}")
+    group_label <- paste0("\\sout{", group_label, "}")
   }
   if (!is.null(color)) {
-    group_label <- paste0("\\\\textcolor", latex_color__(color), "\\{",
-                              group_label, "\\}")
+    group_label <- paste0("\\textcolor", latex_color__(color), "{",
+                              group_label, "}")
   }
   if (!is.null(background)) {
-    group_label <- paste0("\\\\cellcolor", latex_color__(background), "\\{",
-                              group_label, "\\}")
+    group_label <- paste0("\\cellcolor", latex_color__(background), "{",
+                              group_label, "}")
   }
   # Add group label
   if (latex_wrap_text) {
     latex_align <- switch(
       latex_align,
-      "l" = "p{\\\\linewidth}",
-      "c" = ">{\\\\centering\\\\arraybackslash}p{\\\\linewidth}",
-      "r" = ">{\\\\centering\\\\arraybackslash}p{\\\\linewidth}"
+      "l" = "p{\\linewidth}",
+      "c" = ">{\\centering\\arraybackslash}p{\\linewidth}",
+      "r" = ">{\\centering\\arraybackslash}p{\\linewidth}"
     )
   }
 
 
   rowtext <- table_info$contents[start_row + table_info$position_offset]
   if (table_info$booktabs) {
-    pre_rowtext <- paste0("\\\\addlinespace[", gap_space, "]\n")
+    pre_rowtext <- paste0("\\addlinespace[", gap_space, "]\n")
   } else {
     pre_rowtext <- ''
     hline_after <- TRUE
   }
   pre_rowtext <- paste0(
     pre_rowtext,
-    ifelse(hline_before,"\\\\hline\n", ""),
-    "\\\\multicolumn{", ifelse(is.null(colnum),
+    ifelse(hline_before,"\\hline\n", ""),
+    "\\multicolumn{", ifelse(is.null(colnum),
                                table_info$ncol,
                                colnum),
     "}{", latex_align,"}{", group_label,
-    "}\\\\\\\\\n", ifelse(hline_after, "\\\\hline\n", '')
+    "}\\\\\n", ifelse(hline_after, "\\hline\n", '')
   )
   if(!is.null(extra_latex_after)){
     pre_rowtext <- paste0(pre_rowtext,
@@ -301,16 +301,16 @@ group_rows_latex <- function(kable_input, group_label, start_row, end_row,
   new_rowtext <- paste0(pre_rowtext, rowtext)
   if (start_row + 1 == table_info$nrow &
       !is.null(table_info$repeat_header_latex) & table_info$booktabs) {
-    out <- sub(paste0(rowtext, "\\\\\\\\\\*\n"),
-               paste0(new_rowtext, "\\\\\\\\\\*\n"),
+    out <- sub(paste0(rowtext, "\\\\\\*\n"),
+               paste0(new_rowtext, "\\\\\\*\n"),
                out)
   } else {
-    out <- sub(paste0(rowtext, "\\\\\\\\\n"),
-               paste0(new_rowtext, "\\\\\\\\\n"),
+    out <- sub(paste0(rowtext, "\\\\\n"),
+               paste0(new_rowtext, "\\\\\n"),
                out)
   }
 
-  out <- gsub("\\\\addlinespace\n", "", out)
+  out <- gsub("\\addlinespace\n", "", out)
   out <- structure(out, format = "latex", class = "knitr_kable")
   table_info$group_rows_used <- TRUE
   attr(out, "kable_meta") <- table_info

--- a/R/group_rows.R
+++ b/R/group_rows.R
@@ -260,11 +260,11 @@ group_rows_latex <- function(kable_input, group_label, start_row, end_row,
     group_label <- paste0("\\\\sout\\{", group_label, "\\}")
   }
   if (!is.null(color)) {
-    group_label <- paste0("\\\\textcolor", latex_color(color), "\\{",
+    group_label <- paste0("\\\\textcolor", latex_color__(color), "\\{",
                               group_label, "\\}")
   }
   if (!is.null(background)) {
-    group_label <- paste0("\\\\cellcolor", latex_color(background), "\\{",
+    group_label <- paste0("\\\\cellcolor", latex_color__(background), "\\{",
                               group_label, "\\}")
   }
   # Add group label

--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -526,15 +526,15 @@ styling_latex_repeat_header <- function(x, table_info, repeat_header_text,
 styling_latex_full_width <- function(x, table_info) {
   col_align <- as.character(factor(
     table_info$align_vector, c("c", "l", "r"),
-    c(">{\\\\centering}X", ">{\\\\raggedright}X", ">{\\\\raggedleft}X")
+    c(">\\{\\\\centering\\}X", ">\\{\\\\raggedright\\}X", ">\\{\\\\raggedleft\\}X")
   ))
   col_align[is.na(col_align)] <- table_info$align_vector[is.na(col_align)]
   col_align_vector <- col_align
-  col_align <- paste0(" to \\\\linewidth {", paste(col_align, collapse = ""), "}")
-  x <- sub(paste0(table_info$begin_tabular, "\\{[^\\\\n]*\\}"),
-           table_info$begin_tabular, x)
+  col_align <- paste0(" to \\\\linewidth \\{", paste(col_align, collapse = ""), "\\}")
+  x <- sub(paste0(table_info$begin_tabular, "{[^\\n]*}"),
+           table_info$begin_tabular, x, perl = TRUE)
   x <- sub(table_info$begin_tabular,
-      paste0(table_info$begin_tabular, col_align), x)
+      paste0(table_info$begin_tabular, col_align), x, perl = TRUE)
   return(list(x, col_align_vector))
 }
 
@@ -567,7 +567,7 @@ styling_latex_position_center <- function(x, table_info, hold_position,
       x <- styling_latex_HOLD_position(x)
     }
   } else if (table_info$table_env)
-    x <- sub("^\\\\begin\\{table}", "\\\\begin{table}\n\\\\centering", x)
+    x <- sub("^\\begin{table}", "\\begin{table}\n\\centering", x, fixed = TRUE)
   return(x)
 }
 

--- a/R/magic_mirror.R
+++ b/R/magic_mirror.R
@@ -81,7 +81,10 @@ magic_mirror_latex <- function(kable_input){
   }
   # Contents
   table_info$contents <- str_match_all(kable_input, "\n(.*)\\\\\\\\")[[1]][,2]
-  table_info$contents <- regex_escape(table_info$contents, T)
+
+  # this line is commented out because it created problems when using perl=TRUE and the table data includes regexes
+  # table_info$contents <- regex_escape(table_info$contents, T)
+
   if (table_info$tabular == "longtable" & !is.na(table_info$caption) &
       !str_detect(kable_input, "\\\\begin\\{table\\}\\n\\n\\\\caption")) {
     table_info$contents <- table_info$contents[-1]

--- a/R/row_spec.R
+++ b/R/row_spec.R
@@ -209,12 +209,13 @@ row_spec_latex <- function(kable_input, row, bold, italic, monospace,
                                    !is.null(table_info$repeat_header_latex)),
                        gsub, sub)
     if (length(new_row) == 1) {
-      out <- temp_sub(paste0(target_row, "\\\\\\\\"),
-                      paste0(new_row, "\\\\\\\\"), out, perl = T)
+      out <- temp_sub(paste0(target_row, "\\\\"),
+                      paste0(new_row, "\\\\"), out, fixed = TRUE)
       table_info$contents[i] <- new_row
+    # extra_latex_after
     } else {
-      out <- temp_sub(paste0(target_row, "\\\\\\\\"),
-                  paste(new_row, collapse = ""), out, perl = T)
+      out <- temp_sub(paste0(target_row, "\\\\"),
+                  paste(new_row, collapse = ""), out, fixed = TRUE)
       table_info$contents[i] <- new_row[1]
     }
   }
@@ -232,27 +233,27 @@ latex_new_row_builder <- function(target_row, table_info,
   new_row <- latex_row_cells(target_row)
   if (bold) {
     new_row <- lapply(new_row, function(x) {
-      paste0("\\\\textbf\\{", x, "\\}")
+      paste0("\\textbf{", x, "}")
     })
   }
   if (italic) {
     new_row <- lapply(new_row, function(x) {
-      paste0("\\\\em\\{", x, "\\}")
+      paste0("\\em{", x, "}")
     })
   }
   if (monospace) {
     new_row <- lapply(new_row, function(x) {
-      paste0("\\\\ttfamily\\{", x, "\\}")
+      paste0("\\ttfamily{", x, "}")
     })
   }
   if (underline) {
     new_row <- lapply(new_row, function(x) {
-      paste0("\\\\underline\\{", x, "\\}")
+      paste0("\\underline{", x, "}")
     })
   }
   if (strikeout) {
     new_row <- lapply(new_row, function(x) {
-      paste0("\\\\sout\\{", x, "\\}")
+      paste0("\\sout{", x, "}")
     })
   }
   if (!is.null(color)) {
@@ -263,7 +264,7 @@ latex_new_row_builder <- function(target_row, table_info,
     }
     new_row <- lapply(new_row, function(x) {
       x <- clear_color_latex(x)
-      paste0("\\\\textcolor", latex_color(color), "\\{", x, "\\}")
+      paste0("\\textcolor", latex_color__(color), "{", x, "}")
     })
   }
   if (!is.null(background)) {
@@ -274,36 +275,36 @@ latex_new_row_builder <- function(target_row, table_info,
     }
     new_row <- lapply(new_row, function(x) {
       x <- clear_color_latex(x, background = TRUE)
-      paste0("\\\\cellcolor", latex_color(background), "\\{", x, "\\}")
+      paste0("\\cellcolor", latex_color__(background), "{", x, "}")
     })
   }
   if (!is.null(font_size)) {
     new_row <- lapply(new_row, function(x) {
-      paste0("\\\\begingroup\\\\fontsize\\{", font_size, "\\}\\{",
+      paste0("\\begingroup\\fontsize{", font_size, "}{",
              as.numeric(font_size) + 2,
-             "\\}\\\\selectfont ", x, "\\\\endgroup")})
+             "}\\selectfont ", x, "\\endgroup")})
   }
   if (!is.null(align)) {
     if (!is.null(table_info$column_width)) {
       p_align <- switch(align,
-                        "l" = "\\\\raggedright\\\\arraybackslash",
-                        "c" = "\\\\centering\\\\arraybackslash",
-                        "r" = "\\\\raggedleft\\\\arraybackslash")
+                        "l" = "\\raggedright\\arraybackslash",
+                        "c" = "\\centering\\arraybackslash",
+                        "r" = "\\raggedleft\\arraybackslash")
       align <- rep(align, table_info$ncol)
       p_cols <- as.numeric(sub("column_", "", names(table_info$column_width)))
       for (i in 1:length(p_cols)) {
-        align[p_cols[i]] <- paste0("\\>\\{", p_align, "\\}p\\{",
-                                   table_info$column_width[[i]], "\\}")
+        align[p_cols[i]] <- paste0(">{", p_align, "}p{",
+                                   table_info$column_width[[i]], "}")
       }
     }
     new_row <- lapply(new_row, function(x) {
-      paste0("\\\\multicolumn\\{1\\}\\{", align, "\\}\\{", x, "\\}")
+      paste0("\\multicolumn{1}{", align, "}{", x, "}")
     })
   }
 
   if (!is.null(angle)) {
     new_row <- lapply(new_row, function(x) {
-      paste0("\\\\rotatebox\\{", angle, "\\}\\{", x, "\\}")
+      paste0("\\rotatebox{", angle, "}{", x, "}")
     })
   }
 
@@ -316,18 +317,16 @@ latex_new_row_builder <- function(target_row, table_info,
   if (!hline_after & is.null(extra_latex_after)) {
     return(new_row)
   } else {
-    latex_after <- "\\\\\\\\"
+    latex_after <- "\\\\"
     if (hline_after) {
       if (table_info$booktabs) {
-        latex_after <- paste0(latex_after, "\n\\\\midrule")
+        latex_after <- paste0(latex_after, "\n\\midrule")
       } else {
-        latex_after <- paste0(latex_after, "\n\\\\hline")
+        latex_after <- paste0(latex_after, "\n\\hline")
       }
     }
     if (!is.null(extra_latex_after)) {
-      latex_after <- paste0(latex_after, "\n",
-                            regex_escape(extra_latex_after,
-                                         double_backslash = TRUE))
+      latex_after <- paste0(latex_after, "\n", extra_latex_after)
     }
     return(c(new_row, latex_after))
   }

--- a/R/row_spec.R
+++ b/R/row_spec.R
@@ -310,7 +310,7 @@ latex_new_row_builder <- function(target_row, table_info,
   new_row <- paste(unlist(new_row), collapse = " & ")
 
   # if (!is.null(background)) {
-  #   new_row <- paste0("\\\\rowcolor", latex_color(background), "  ", new_row)
+  #   new_row <- paste0("\\\\rowcolor", latex_color__(background), "  ", new_row)
   # }
 
   if (!hline_after & is.null(extra_latex_after)) {

--- a/R/row_spec.R
+++ b/R/row_spec.R
@@ -212,7 +212,6 @@ row_spec_latex <- function(kable_input, row, bold, italic, monospace,
       out <- temp_sub(paste0(target_row, "\\\\"),
                       paste0(new_row, "\\\\"), out, fixed = TRUE)
       table_info$contents[i] <- new_row
-    # extra_latex_after
     } else {
       out <- temp_sub(paste0(target_row, "\\\\"),
                   paste(new_row, collapse = ""), out, fixed = TRUE)

--- a/R/spec_tools.R
+++ b/R/spec_tools.R
@@ -62,7 +62,7 @@ latex_color__ <- function(color) {
     return(paste0("[HTML]{", color, "}"))
   }
 }
-latex_color <- function(colors, escape = TRUE) {
+latex_color <- function(colors, escape = FALSE) {
   colors <- as.character(colors)
   if (escape) {
     return(sapply(colors, latex_color_))

--- a/inst/rmarkdown/test_column_spec.Rmd
+++ b/inst/rmarkdown/test_column_spec.Rmd
@@ -1,0 +1,19 @@
+---
+output: pdf_document
+---
+
+```{r}
+library(kableExtra)
+df <- data.frame(a = 1:4, b = 4:7)
+kbl(df, format = "latex") |>
+    column_spec(2,
+        bold = TRUE,
+        monospace = TRUE,
+        underline = TRUE,
+        italic = TRUE,
+        color = "red",
+        background = "#FFFF00",
+        width = "3in",
+        border_right = TRUE
+        )
+```

--- a/inst/rmarkdown/test_column_spec.Rmd
+++ b/inst/rmarkdown/test_column_spec.Rmd
@@ -17,3 +17,10 @@ kbl(df, format = "latex") |>
         border_right = TRUE
         )
 ```
+
+```{r}
+dt <- mtcars[1:5, 1:6]
+kbl(dt, format = "latex", booktabs = TRUE) %>%
+  kable_styling(full_width = TRUE) %>%
+  column_spec(1, width = "8cm")
+```

--- a/inst/rmarkdown/test_row_spec.Rmd
+++ b/inst/rmarkdown/test_row_spec.Rmd
@@ -1,0 +1,55 @@
+---
+output: pdf_document
+---
+
+```{r}
+library(kableExtra)
+df <- data.frame(1:4, 4:7)
+kbl(df, format = "latex") |>
+    row_spec(3,
+        bold = TRUE,
+        monospace = TRUE,
+        underline = TRUE,
+        italic = TRUE)
+```
+
+```{r}
+kbl(df, format = "latex") |>
+    row_spec(3, angle = 45)
+```
+
+```{r}
+kbl(df, format = "latex") |>
+    row_spec(3, font_size = 20)
+```
+
+```{r}
+kbl(df, format = "latex") |>
+    row_spec(3, color = "blue", background = "pink")
+```
+
+```{r}
+kbl(df, format = "latex", booktabs = TRUE) |>
+    kable_classic() |>
+    row_spec(3, hline_after = TRUE)
+```
+
+
+```{r}
+collapse_rows_dt <- data.frame(
+    C1 = c(rep("a", 10), rep("b", 5)),
+    C2 = c(rep("c", 7), rep("d", 3), rep("c", 2), rep("d", 3)),
+    C3 = 1:15,
+    C4 = sample(c(0, 1), 15, replace = TRUE))
+kbl(collapse_rows_dt[-1], format = "latex", align = "c", booktabs = T) %>%
+    column_spec(1, bold = T, width = "5em") %>%
+    row_spec(c(1:7, 11:12) - 1, extra_latex_after = "\\rowcolor{gray!6}") %>%
+    collapse_rows(1, latex_hline = "none")
+```
+
+```{r}
+df <- data.frame(a = c("ab", "abc"), b = c("abcd", "abcde"))
+kbl(df, format = "latex") |>
+    row_spec(1, align = "r") |>
+    row_spec(2, align = "c")
+```

--- a/tests/testthat/_snaps/column_spec.md
+++ b/tests/testthat/_snaps/column_spec.md
@@ -20,3 +20,22 @@
       \hline
       \end{tabular}
 
+---
+
+    Code
+      kbl(dt, format = "latex", booktabs = TRUE) %>% kable_styling(full_width = TRUE) %>%
+        column_spec(1, width = "8cm")
+    Output
+      
+      \begin{tabu} to \linewidth {>{\raggedright\arraybackslash}p{8cm}>{\raggedleft}X>{\raggedleft}X>{\raggedleft}X>{\raggedleft}X>{\raggedleft}X>{\raggedleft}X}
+      \toprule
+        & mpg & cyl & disp & hp & drat & wt\\
+      \midrule
+      Mazda RX4 & 21.0 & 6 & 160 & 110 & 3.90 & 2.620\\
+      Mazda RX4 Wag & 21.0 & 6 & 160 & 110 & 3.90 & 2.875\\
+      Datsun 710 & 22.8 & 4 & 108 & 93 & 3.85 & 2.320\\
+      Hornet 4 Drive & 21.4 & 6 & 258 & 110 & 3.08 & 3.215\\
+      Hornet Sportabout & 18.7 & 8 & 360 & 175 & 3.15 & 3.440\\
+      \bottomrule
+      \end{tabu}
+

--- a/tests/testthat/_snaps/column_spec.md
+++ b/tests/testthat/_snaps/column_spec.md
@@ -1,0 +1,22 @@
+# Rmarkdown example from inst/
+
+    Code
+      column_spec(kbl(df, format = "latex"), 2, bold = TRUE, monospace = TRUE,
+      underline = TRUE, italic = TRUE, color = "red", background = "#FFFF00", width = "3in",
+      border_right = TRUE)
+    Output
+      
+      \begin{tabular}[t]{r|>{\raggedleft\arraybackslash}p{3in}|}
+      \hline
+      a & b\\
+      \hline
+      1 & \cellcolor[HTML]{FFFF00}{\textcolor{red}{\underline{\ttfamily{\em{\textbf{4}}}}}}\\
+      \hline
+      2 & \cellcolor[HTML]{FFFF00}{\textcolor{red}{\underline{\ttfamily{\em{\textbf{5}}}}}}\\
+      \hline
+      3 & \cellcolor[HTML]{FFFF00}{\textcolor{red}{\underline{\ttfamily{\em{\textbf{6}}}}}}\\
+      \hline
+      4 & \cellcolor[HTML]{FFFF00}{\textcolor{red}{\underline{\ttfamily{\em{\textbf{7}}}}}}\\
+      \hline
+      \end{tabular}
+

--- a/tests/testthat/_snaps/row_spec.md
+++ b/tests/testthat/_snaps/row_spec.md
@@ -82,6 +82,27 @@
 ---
 
     Code
+      row_spec(kable_classic(kbl(df, format = "latex", booktabs = TRUE)), 3,
+      hline_after = TRUE)
+    Output
+      \begin{table}
+      \centering
+      \begin{tabular}[t]{rr}
+      \toprule
+      X1.4 & X4.7\\
+      \midrule
+      1 & 4\\
+      2 & 5\\
+      3 & 6\\
+      \midrule
+      4 & 7\\
+      \bottomrule
+      \end{tabular}
+      \end{table}
+
+---
+
+    Code
       row_spec(row_spec(kbl(df, format = "latex"), 1, align = "r"), 2, align = "c")
     Output
       
@@ -93,6 +114,45 @@
       \hline
       \multicolumn{1}{c}{abc} & \multicolumn{1}{c}{abcde}\\
       \hline
+      \end{tabular}
+
+# extra_latex_after: Example from documentation
+
+    Code
+      kbl(collapse_rows_dt[-1], format = "latex", align = "c", booktabs = TRUE) %>%
+        column_spec(1, bold = T, width = "5em") %>% row_spec(c(1:7, 11:12) - 1,
+      extra_latex_after = "\\rowcolor{gray!6}") %>% collapse_rows(1, latex_hline = "none")
+    Output
+      
+      \begin{tabular}[t]{>{\centering\arraybackslash}p{5em}cc}
+      \toprule
+      C2 & C3 & C4\\
+      \rowcolor{gray!6}
+      \midrule
+      \textbf{c} & 1 & 1\\
+      \rowcolor{gray!6}
+      \textbf{c} & 2 & 0\\
+      \rowcolor{gray!6}
+      \textbf{c} & 3 & 0\\
+      \rowcolor{gray!6}
+      \textbf{c} & 4 & 0\\
+      \rowcolor{gray!6}
+      \textbf{c} & 5 & 1\\
+      \rowcolor{gray!6}
+      \textbf{c} & 6 & 1\\
+      \rowcolor{gray!6}
+      \textbf{c} & 7 & 1\\
+      \textbf{d} & 8 & 1\\
+      \textbf{d} & 9 & 1\\
+      \textbf{d} & 10 & 0\\
+      \rowcolor{gray!6}
+      \textbf{c} & 11 & 0\\
+      \rowcolor{gray!6}
+      \textbf{c} & 12 & 0\\
+      \textbf{d} & 13 & 1\\
+      \textbf{d} & 14 & 0\\
+      \textbf{d} & 15 & 1\\
+      \bottomrule
       \end{tabular}
 
 # issue #582: RMD kable styling repeates rows when rendering striped table to LaTeX in some data combination

--- a/tests/testthat/_snaps/row_spec.md
+++ b/tests/testthat/_snaps/row_spec.md
@@ -1,0 +1,117 @@
+# LaTeX: basic argument tests
+
+    Code
+      row_spec(kbl(df, format = "latex"), 3, bold = TRUE, monospace = TRUE,
+      underline = TRUE, italic = TRUE)
+    Output
+      
+      \begin{tabular}[t]{r|r}
+      \hline
+      X1.4 & X4.7\\
+      \hline
+      1 & 4\\
+      \hline
+      2 & 5\\
+      \hline
+      \underline{\ttfamily{\em{\textbf{3}}}} & \underline{\ttfamily{\em{\textbf{6}}}}\\
+      \hline
+      4 & 7\\
+      \hline
+      \end{tabular}
+
+---
+
+    Code
+      row_spec(kbl(df, format = "latex"), 3, angle = 45)
+    Output
+      
+      \begin{tabular}[t]{r|r}
+      \hline
+      X1.4 & X4.7\\
+      \hline
+      1 & 4\\
+      \hline
+      2 & 5\\
+      \hline
+      \rotatebox{45}{3} & \rotatebox{45}{6}\\
+      \hline
+      4 & 7\\
+      \hline
+      \end{tabular}
+
+---
+
+    Code
+      row_spec(kbl(df, format = "latex"), 3, font_size = 10)
+    Output
+      
+      \begin{tabular}[t]{r|r}
+      \hline
+      X1.4 & X4.7\\
+      \hline
+      1 & 4\\
+      \hline
+      2 & 5\\
+      \hline
+      \begingroup\fontsize{10}{12}\selectfont 3\endgroup & \begingroup\fontsize{10}{12}\selectfont 6\endgroup\\
+      \hline
+      4 & 7\\
+      \hline
+      \end{tabular}
+
+---
+
+    Code
+      row_spec(kbl(df, format = "latex"), 3, color = "blue", background = "pink")
+    Output
+      
+      \begin{tabular}[t]{r|r}
+      \hline
+      X1.4 & X4.7\\
+      \hline
+      1 & 4\\
+      \hline
+      2 & 5\\
+      \hline
+      \cellcolor{pink}{\textcolor{blue}{3}} & \cellcolor{pink}{\textcolor{blue}{6}}\\
+      \hline
+      4 & 7\\
+      \hline
+      \end{tabular}
+
+---
+
+    Code
+      row_spec(row_spec(kbl(df, format = "latex"), 1, align = "r"), 2, align = "c")
+    Output
+      
+      \begin{tabular}[t]{l|l}
+      \hline
+      a & b\\
+      \hline
+      \multicolumn{1}{r}{ab} & \multicolumn{1}{r}{abcd}\\
+      \hline
+      \multicolumn{1}{c}{abc} & \multicolumn{1}{c}{abcde}\\
+      \hline
+      \end{tabular}
+
+# issue #582: RMD kable styling repeates rows when rendering striped table to LaTeX in some data combination
+
+    Code
+      kable_styling(kbl(dfWithDot, format = "latex"), latex_options = "striped")
+    Output
+      \begin{table}
+      \centering
+      \begin{tabular}[t]{l|l|l|l|l}
+      \hline
+      A & B1 & B2 & B3 & B.\\
+      \hline
+      \cellcolor{gray!10}{A1} & \cellcolor{gray!10}{A1B1} & \cellcolor{gray!10}{A1B2} & \cellcolor{gray!10}{A1B3} & \cellcolor{gray!10}{A1B.}\\
+      \hline
+      A2 & A2B1 & A2B2 & A2B3 & A2B.\\
+      \hline
+      \cellcolor{gray!10}{A.} & \cellcolor{gray!10}{A.B1} & \cellcolor{gray!10}{A.B2} & \cellcolor{gray!10}{A.B3} & \cellcolor{gray!10}{A.B.}\\
+      \hline
+      \end{tabular}
+      \end{table}
+

--- a/tests/testthat/test-column_spec.R
+++ b/tests/testthat/test-column_spec.R
@@ -1,0 +1,25 @@
+# TODO: use system.file() instead of here::here()
+test_that("Rmarkdown  compilation", {
+    tmp <- tempfile(fileext = ".Rmd")
+    file.copy(here::here("inst/rmarkdown/test_column_spec.Rmd"), tmp)
+    compile <- try(rmarkdown::render(tmp, quiet = TRUE), silent = TRUE)
+    expect_false(inherits(compile, "try-error"))
+})
+
+
+test_that("Rmarkdown example from inst/", {
+    df <- data.frame(a = 1:4, b = 4:7)
+    expect_snapshot(
+        kbl(df, format = "latex") |>
+            column_spec(2,
+                bold = TRUE,
+                monospace = TRUE,
+                underline = TRUE,
+                italic = TRUE,
+                color = "red",
+                background = "#FFFF00",
+                width = "3in",
+                border_right = TRUE
+            )
+    )
+})

--- a/tests/testthat/test-column_spec.R
+++ b/tests/testthat/test-column_spec.R
@@ -22,4 +22,11 @@ test_that("Rmarkdown example from inst/", {
                 border_right = TRUE
             )
     )
+
+    dt <- mtcars[1:5, 1:6]
+    expect_snapshot(
+        kbl(dt, format = "latex", booktabs = TRUE) %>%
+            kable_styling(full_width = TRUE) %>%
+            column_spec(1, width = "8cm")
+    )
 })

--- a/tests/testthat/test-indent-html.R
+++ b/tests/testthat/test-indent-html.R
@@ -1,5 +1,3 @@
-context("add_indent")
-
 test_that("add_indent can add to 1 row", {
   observed <- kable(mtcars[1:4, 1:3], "html") %>%
     add_indent(1) %>%

--- a/tests/testthat/test-indent-latex.R
+++ b/tests/testthat/test-indent-latex.R
@@ -1,5 +1,3 @@
-context("add_indent")
-
 test_that("add_indent can add to 1 row", {
   observed <- kable(mtcars[1:4, 1:3], "latex") %>%
     add_indent(1) %>%

--- a/tests/testthat/test-row_spec.R
+++ b/tests/testthat/test-row_spec.R
@@ -1,3 +1,12 @@
+# TODO: use system.file() instead of here::here()
+test_that("Rmarkdown  compilation", {
+    tmp <- tempfile(fileext = ".Rmd")
+    file.copy(here::here("inst/rmarkdown/test_row_spec.Rmd"), tmp)
+    compile <- try(rmarkdown::render(tmp, quiet = TRUE), silent = TRUE)
+    expect_false(inherits(compile, "try-error"))
+})
+
+
 test_that("LaTeX: basic argument tests", {
     df <- data.frame(1:4, 4:7)
 
@@ -41,19 +50,19 @@ test_that("LaTeX: basic argument tests", {
 })
 
 
-
+# TODO: This is broken. The last column values seem to change sometimes
 test_that("extra_latex_after: Example from documentation", {
     collapse_rows_dt <- data.frame(
         C1 = c(rep("a", 10), rep("b", 5)),
         C2 = c(rep("c", 7), rep("d", 3), rep("c", 2), rep("d", 3)),
         C3 = 1:15,
         C4 = sample(c(0, 1), 15, replace = TRUE))
-    Q
-    pkgload::load_all()
-    k = kbl(collapse_rows_dt[-1], format = "latex", align = "c", booktabs = TRUE) %>%
-        column_spec(1, bold = T, width = "5em") %>%
-        row_spec(c(1:7, 11:12) - 1, extra_latex_after = "\\rowcolor{gray!6}") %>%
-        collapse_rows(1, latex_hline = "none")
+    expect_snapshot(
+        kbl(collapse_rows_dt[-1], format = "latex", align = "c", booktabs = TRUE) %>%
+            column_spec(1, bold = T, width = "5em") %>%
+            row_spec(c(1:7, 11:12) - 1, extra_latex_after = "\\rowcolor{gray!6}") %>%
+            collapse_rows(1, latex_hline = "none")
+    )
 })
 
 

--- a/tests/testthat/test-row_spec.R
+++ b/tests/testthat/test-row_spec.R
@@ -1,0 +1,71 @@
+test_that("LaTeX: basic argument tests", {
+    df <- data.frame(1:4, 4:7)
+
+    expect_snapshot(
+        kbl(df, format = "latex") |>
+            row_spec(3,
+                bold = TRUE,
+                monospace = TRUE,
+                underline = TRUE,
+                italic = TRUE
+            )
+    )
+
+    expect_snapshot(
+        kbl(df, format = "latex") |>
+            row_spec(3, angle = 45)
+    )
+
+    expect_snapshot(
+        kbl(df, format = "latex") |>
+            row_spec(3, font_size = 10)
+    )
+
+    expect_snapshot(
+        kbl(df, format = "latex") |>
+            row_spec(3, color = "blue", background = "pink")
+    )
+
+    expect_snapshot(
+        kbl(df, format = "latex", booktabs = TRUE) |>
+            kable_classic() |>
+            row_spec(3, hline_after = TRUE)
+    )
+
+    df <- data.frame(a = c("ab", "abc"), b = c("abcd", "abcde"))
+    expect_snapshot(
+        kbl(df, format = "latex") |>
+            row_spec(1, align = "r") |>
+            row_spec(2, align = "c")
+    )
+})
+
+
+
+test_that("extra_latex_after: Example from documentation", {
+    collapse_rows_dt <- data.frame(
+        C1 = c(rep("a", 10), rep("b", 5)),
+        C2 = c(rep("c", 7), rep("d", 3), rep("c", 2), rep("d", 3)),
+        C3 = 1:15,
+        C4 = sample(c(0, 1), 15, replace = TRUE))
+    Q
+    pkgload::load_all()
+    k = kbl(collapse_rows_dt[-1], format = "latex", align = "c", booktabs = TRUE) %>%
+        column_spec(1, bold = T, width = "5em") %>%
+        row_spec(c(1:7, 11:12) - 1, extra_latex_after = "\\rowcolor{gray!6}") %>%
+        collapse_rows(1, latex_hline = "none")
+})
+
+
+test_that("issue #582: RMD kable styling repeates rows when rendering striped table to LaTeX in some data combination", {
+    dfWithDot <- data.frame(
+        A = c("A1", "A2", "A."),
+        B1 = c("A1B1", "A2B1", "A.B1"),
+        B2 = c("A1B2", "A2B2", "A.B2"),
+        B3 = c("A1B3", "A2B3", "A.B3"),
+        B. = c("A1B.", "A2B.", "A.B."))
+    expect_snapshot(
+        kbl(dfWithDot, format = "latex") |>
+            kable_styling(latex_options = "striped")
+    )
+})

--- a/tests/testthat/test-xml-to-html-table.R
+++ b/tests/testthat/test-xml-to-html-table.R
@@ -26,5 +26,5 @@ for (test_case in list(
 )) {
   returned_table <- read_table_data_from_xml(kable_as_xml(test_case))
   returned_table[] <- lapply(returned_table, as.numeric)
-  testthat::expect_equivalent(returned_table,expected_table)
+  testthat::expect_equal(returned_table,expected_table, ignore_attr = TRUE)
 }


### PR DESCRIPTION
There is a problematic pattern in `row_spec()`, `column_spec()` and maybe elsewhere:

1. Extract row contents with `magic_mirror(kable_input)`
2. Feed the content of the row as the first argument to `gsub(row, row_modified, perl=TRUE)`

In many cases, this works well to modify the table. But whenever the content of the row includes regex tokens, the results are unpredictable.

For example, in issue #582 , the command produces bad results because the row includes dots, which are interpreted as "any character". I suspect that several of the weird corner case bugs reported on the issue tracker stem from this.

This work-in-progress PR switches `perl=TRUE` to `fixed=TRUE`, and makes other attendant changes. Since changing these internals could have unpredictable results, I also add a lot of snapshot tests and also tests to see if Rmarkdown documents can compile to PDF.

TODO:

* [ ] `[!h]` visible in some tables in `awesome_table_in_pdf.pdf`
* [ ] Test indent
* [ ] Figure out the complex regex in `add_indent()`
* [ ] cleaner solution to the `\\makecell` double escape
* [ ] Extra space in last cell of best_practice doc