### PR TITLE
merge NEWS for 1.3.5 with 1.4.0

### DIFF
--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -19,6 +19,7 @@ part that gets impacted is the table labels or references set within the kable
 function through the label option. For this part, first, people can set labels
 using knitr chunk options. Also, people can easily overcome it by either using
 kbl or setting format in kable.
+* Added line_col to spec_pointrange()
 
 Improvements:
 
@@ -61,11 +62,6 @@ functionality.
 * Merged various pull requests improving codebase and resolving issues (#800,
 #799, #797, #798, #794, #793, #768, #632, #628, etc.).
 
-
-kableExtra 1.3.5
---------------------------------------------------------------------------------
-
-* Added line_col to spec_pointrange()
 
 kableExtra 1.3.1, 1.3.3, 1.3.4
 --------------------------------------------------------------------------------


### PR DESCRIPTION
As there has been no version 1.3.5 of `kableExtra` in CRAN, merge sections 1.3.5 and 1.4.0 of NEWS.md into 1.4.0