### PR TITLE
Stop row_spec() from adding extra linebreaks.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kableExtra
 Type: Package
 Title: Construct Complex Table with 'kable' and Pipe Syntax
-Version: 1.4.0.1
+Version: 1.4.0.2
 Authors@R: c(
     person('Hao', 'Zhu', email = 'haozhu233@gmail.com', role = c('aut', 'cre'),
     comment = c(ORCID = '0000-0002-3386-6076')),

--- a/R/row_spec.R
+++ b/R/row_spec.R
@@ -215,9 +215,9 @@ row_spec_latex <- function(kable_input, row, bold, italic, monospace,
                                      underline, strikeout,
                                      color, background, align, font_size, angle,
                                      hline_after, extra_latex_after)
-    temp_sub <- ifelse(i == 1 & (table_info$tabular == "longtable" |
-                                   !is.null(table_info$repeat_header_latex)),
-                       gsub, sub)
+    temp_sub <- if (i == 1 && (table_info$tabular == "longtable" ||
+                                   !is.null(table_info$repeat_header_latex)))
+                  gsub else sub
     if (length(new_row) == 1) {
       # fixed=TRUE is safer but does not always work
       regex <- paste0("\\Q", target_row, "\\E")
@@ -230,7 +230,7 @@ row_spec_latex <- function(kable_input, row, bold, italic, monospace,
       table_info$contents[i] <- new_row
     } else {
       # fixed=TRUE is safer but does not always work
-      regex <- paste0("\\Q", target_row, "\\E")
+      regex <- paste0("\\Q", target_row, "\\E(\\\\\\\\)?")
       if (any(grepl(regex, out))) {
         out <- temp_sub(regex,
           paste(new_row, collapse = ""), out, perl = TRUE)

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,10 +1,12 @@
-kableExtra 1.4.0.1
+kableExtra 1.4.0.2
 --------------------------------------------------------------------------------
 
 Bug Fixes:
 
 * Fixed a bug in `collapse_rows()`, which failed on tables
 that had no header (#812).
+* Fixed a bug in `row_spec()` which added extra 
+line breaks when `extra_latex_after` was specified (#815).
 
 
 kableExtra 1.4.0


### PR DESCRIPTION
Fixes #815 

Also replace preceding ifelse() with if() ... else ... to be more efficient.