### PR TITLE
TeXLive updates frequently; this makes sure we have the latest `tlmgr`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,6 +34,7 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-tinytex@v2
+      - run: tlmgr update --self
       - run: tlmgr --version
       - run: tlmgr install colortbl grfext ae
       - run: tlmgr list --only-installed


### PR DESCRIPTION
... so it doesn't fail.  See https://github.com/r-lib/actions/issues/801 .