### PR TITLE
`md_table_parser()` assumed pipe characters were always in the same column

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kableExtra
 Type: Package
 Title: Construct Complex Table with 'kable' and Pipe Syntax
-Version: 1.4.0.2
+Version: 1.4.0.3
 Authors@R: c(
     person('Hao', 'Zhu', email = 'haozhu233@gmail.com', role = c('aut', 'cre'),
     comment = c(ORCID = '0000-0002-3386-6076')),

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,4 +1,4 @@
-kableExtra 1.4.0.2
+kableExtra 1.4.0.3
 --------------------------------------------------------------------------------
 
 Bug Fixes:
@@ -7,6 +7,8 @@ Bug Fixes:
 that had no header (#812).
 * Fixed a bug in `row_spec()` which added extra 
 line breaks when `extra_latex_after` was specified (#815).
+* Fixed a bug in `kable_styling()` which didn't parse 
+"pipe" tables containing multibyte characters properly (#821).
 
 
 kableExtra 1.4.0


### PR DESCRIPTION
... but they might not be.

Fixes #821.