### PR TITLE
Handle backslashes in new header text.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kableExtra
 Type: Package
 Title: Construct Complex Table with 'kable' and Pipe Syntax
-Version: 1.4.0.3
+Version: 1.4.0.4
 Authors@R: c(
     person('Hao', 'Zhu', email = 'haozhu233@gmail.com', role = c('aut', 'cre'),
     comment = c(ORCID = '0000-0002-3386-6076')),

--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -314,6 +314,11 @@ pdfTable_add_header_above <- function(kable_input, header, bold, italic,
 
   if (escape) {
     header$header <- input_escape(header$header, align)
+  } else {
+    # Issue 836:  backslashes in the replacement
+    # need to be escaped.  We can't use fixed() below,
+    # because we need the regexp pattern.
+    header$header <- gsub("\\\\", "\\\\\\\\", header$header)
   }
 
   align <- vapply(align, match.arg, 'a', choices = c("l", "c", "r"))

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,4 +1,4 @@
-kableExtra 1.4.0.3
+kableExtra 1.4.0.4
 --------------------------------------------------------------------------------
 
 Bug Fixes:
@@ -9,6 +9,9 @@ that had no header (#812).
 line breaks when `extra_latex_after` was specified (#815).
 * Fixed a bug in `kable_styling()` which didn't parse 
 "pipe" tables containing multibyte characters properly (#821).
+* Fixed a bug in `add_header_above()` which caused headers
+containing LaTeX code to be rendered incorrectly in LaTeX 
+documents (#836).
 
 
 kableExtra 1.4.0

--- a/tests/testthat/_snaps/bugfix.md
+++ b/tests/testthat/_snaps/bugfix.md
@@ -1,3 +1,20 @@
+# Issue #836:  latex allowed in add_header_above
+
+    Code
+      add_header_above(kbl(mtcars[1:2, 1:2], col.names = NULL, format = "latex"),
+      "\\textbf{HEADER}", escape = FALSE)
+    Output
+      
+      \begin{tabular}[t]{l|r|r}
+      \hline
+      \multicolumn{1}{c}{\textbf{HEADER}} \\
+      \cline{1-1}
+      Mazda RX4 & 21 & 6\\
+      \hline
+      Mazda RX4 Wag & 21 & 6\\
+      \hline
+      \end{tabular}
+
 # Issue #806: custom rule widths
 
     Code

--- a/tests/testthat/test-bugfix.R
+++ b/tests/testthat/test-bugfix.R
@@ -1,3 +1,12 @@
+test_that("Issue #836:  latex allowed in add_header_above", {
+  expect_snapshot(
+    kbl(mtcars[1:2, 1:2], col.names=NULL,
+             format = "latex") |>
+    add_header_above("\\textbf{HEADER}", escape = FALSE)
+  )
+}
+)
+
 test_that("Issue #812:  table without header works in collapse_rows", {
   tab <- kbl(mtcars[1:3, 1:4], col.names = NULL,
              format = "html", booktabs = TRUE) |>


### PR DESCRIPTION
  Fixes #836.