### PR TITLE
Detect Quarto and protect MathJax .

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kableExtra
 Type: Package
 Title: Construct Complex Table with 'kable' and Pipe Syntax
-Version: 1.4.0.4
+Version: 1.4.0.5
 Authors@R: c(
     person('Hao', 'Zhu', email = 'haozhu233@gmail.com', role = c('aut', 'cre'),
     comment = c(ORCID = '0000-0002-3386-6076')),

--- a/R/kbl.R
+++ b/R/kbl.R
@@ -105,6 +105,20 @@ kbl <- function(x, format, digits = getOption("digits"),
       table.envir = table.envir, ...
     )
   } else if (format == "html") {
+    if (inQuarto()) {
+      for (i in seq_len(ncol(x))) {
+        col <- x[, i]
+        if (is.character(col)) {
+          hasMath <- grep("\\$.*\\$", col)
+          if (length(hasMath)) {
+            if (escape)
+              warning("Should use `escape = FALSE` in Quarto with math")
+            col[hasMath] <- make_data_qmd(col[hasMath])
+            x[, i] <- col
+          }
+        }
+      }
+    }
     out <- knitr::kable(
       x = x, format = format, digits = digits,
       row.names = row.names, col.names = col.names, align = align,

--- a/R/util.R
+++ b/R/util.R
@@ -363,3 +363,15 @@ md_table_parser <- function(md_table) {
 toprule_regexp <- "(\\\\toprule(\\[[^]]*])?)"
 midrule_regexp <- "(\\\\midrule(\\[[^]]*])?)"
 bottomrule_regexp <- "(\\\\bottomrule(\\[[^]]*])?)"
+
+# Detect if we are running in Quarto
+
+inQuarto <- function()
+  !is.null(knitr::opts_knit$get("quarto.version"))
+
+# Modify math so Quarto handles it properly
+# Written by Christophe Dervieux in issue #746
+
+make_data_qmd <- function(content) {
+  sprintf('<span data-qmd="%s">%s</span>', content, content)
+}

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,5 +1,10 @@
-kableExtra 1.4.0.4
+kableExtra 1.4.0.5
 --------------------------------------------------------------------------------
+
+New Features:
+
+* Now attempts to handle MathJax in Quarto documents.
+This requires you to call `kbl(escape = FALSE)` (#746).
 
 Bug Fixes:
 


### PR DESCRIPTION
This is so just a draft PR at the moment.  Some issues:

 - If it detects Quarto, it wraps the contents of any cell containing two dollar signs with a <span> wrapper as suggested by @cderv.  That will catch false positives, e.g. multiple dollar amounts.  Is this a problem?
 - It issues a warning if it has done the wrapping but the user had `escape = TRUE`.  Should it just ignore that case?

When done, this fixes #746 .