### PR TITLE
giving option to show table footnotes on every page

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,6 @@ Suggests:
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)
 Language: en-US

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -27,6 +27,8 @@
 #' @param fixed_small_size T/F When you want to keep the footnote small after
 #' specifying large font size with the kable_styling() (e.g. ideal font for headers
 #' and table content with small font in footnotes).
+#' @param show_every_page T/F To make footnotes print at bottom of all pages for
+#' long tables.
 #' @param general_title Section header for general footnotes. Default is
 #' "Note: ".
 #' @param number_title Section header for number footnotes. Default is "".
@@ -64,6 +66,7 @@ footnote <- function(kable_input,
                      escape = TRUE,
                      threeparttable = FALSE,
                      fixed_small_size = FALSE,
+                     show_every_page = FALSE,
                      general_title = "Note: ",
                      number_title = "",
                      alphabet_title = "",
@@ -127,7 +130,7 @@ footnote <- function(kable_input,
   }
   if (kable_format == "latex") {
     return(footnote_latex(kable_input, footnote_table, footnote_as_chunk,
-                          threeparttable, fixed_small_size))
+                          threeparttable, fixed_small_size, show_every_page))
   }
 }
 
@@ -265,7 +268,7 @@ html_tfoot_maker_ <- function(ft_contents, ft_title, ft_type, ft_chunk) {
 
 # LaTeX
 footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
-                           threeparttable, fixed_small_size) {
+                           threeparttable, fixed_small_size, show_every_page) {
   table_info <- magic_mirror(kable_input)
   out <- solve_enc(kable_input)
 
@@ -312,9 +315,24 @@ footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
     if (table_info$booktabs) {
       out <- sub(bottomrule_regexp,
                  paste0("\\1\n", footnote_text), out)
+
     } else {
       out <- sub(table_info$end_tabular,
                  paste0(footnote_text, "\n\\\\end{", table_info$tabular, "}"),
+                 out)
+    }
+  }
+  if (show_every_page) {
+    if (table_info$booktabs) {
+      out <- sub("\\\\endhead\\n\\n\\\\endfoot",
+                 "\\\\endhead\n\\\\midrule\n\\\\insertTableNotes\n\\\\endfoot",
+                 out)
+    } else {
+      out <- sub("\\\\insertTableNotes\\n",
+                 "",
+                 out)
+      out <- sub("\\\\endhead\\n",
+                 "\\\\endhead\n\\\\hline\n\\\\insertTableNotes\n\\\\endfoot\n",
                  out)
     }
   }

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -330,46 +330,53 @@ footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
   }
 
   if (table_info$tabular == "longtable" & show_every_page) {
-    fn_regexp <- ifelse(threeparttable, "\\\\insertTableNotes", footnote_text)
+    fn_regexp <- paste0(
+      ifelse(table_info$booktabs, "\\\\midrule", ""),
+      ifelse(threeparttable, "\\\\insertTableNotes", footnote_text))
     fn_text <- gsub("\\\\", "\\", fn_regexp, fixed = TRUE)
-    if (is.null(table_info$repeat_header_latex)) {
+
+    if(is.null(table_info$repeat_header_latex)) {
       # need full \begin{longtable} command
       # table_info valign2 ok but align missing vertical lines
       longtable_start <- sub(".*\\\\begin\\{longtable\\}",
                              "\\\\begin\\{longtable\\}", out)
       longtable_text <- sub("\n.*", "", longtable_start)
-      out <- sub(longtable_text,
-                 paste(longtable_text,
-                       ifelse(table_info$booktabs, "\\midrule\n", ""),
-                       paste0("\n", fn_text, "\n\\endfoot\n")),
-                 out, fixed = TRUE)
+
+      if(!table_info$booktabs){
+        print(paste("basic and not bt:")) #, grepl(longtable_text, out)))
+        out <- sub(longtable_text,
+                   paste(longtable_text, "\n",
+                         fn_text, "\n\\endfoot\n"),
+                   out, fixed = TRUE)
+      } else {
+        print(paste("basic and bt")) #, grepl(longtable_text, out)))
+        out <- sub(longtable_text,
+                   paste(longtable_text, # "\n\\midrule\n",
+                         fn_text, "\n\\endfoot\n"),
+                   out, fixed = TRUE)
+      }
     } else {
-      text_pattern <- ifelse(table_info$booktabs,
-                             "\\\\endhead\\n\\n\\\\endfoot\\n",
-                             "\\\\endhead\n")
-      text_replace <- ifelse(threeparttable,
-                             paste0(
-                               "\\\\endhead\n",
-                               "\\\\midrule\n", fn_regexp, "\n\\\\endfoot\n")
-                               # "\\\\midrule\n",
-                               # fn_regexp, "\n\\\\endlastfoot\n"),
-                             paste0("\\\\endhead\n", fn_regexp, "\n\\\\endfoot\n"))
-      out <- sub(text_pattern, text_replace, out)
-      # if (table_info$booktabs) {
-      #   out <- sub(
-      #     "\\\\endhead\\n\\n\\\\endfoot\\n",
-      #     paste0(
-      #       "\\\\endhead\n",
-      #       "\\\\midrule\n", fn_regexp, "\n\\\\endfoot\n",
-      #       # "\\\\midrule\n",
-      #       fn_regexp, "\n\\\\endlastfoot\n"),
-      #     out)
-      # } else {
-      #   out <- sub(
-      #     "\\\\endhead\n",
-      #     paste0("\\\\endhead\n", fn_regexp, "\n\\\\endfoot\n"),
-      #     out)
-      # }
+      if(!table_info$booktabs){
+        print(paste("repeat and not bt", grepl("\\\\endhead\\n", out)))
+        out <- sub(
+          "\\\\endhead\\n",
+          paste0(
+            "\\\\endhead\n",
+            fn_regexp, "\n\\\\endfoot\n",
+            fn_regexp, "\n\\\\endlastfoot\n"),
+          out)
+      } else {
+        print(paste("repeat and bt", grepl("\\\\endhead\\n\\n\\\\endfoot\\n", out)))
+        out <- sub(
+          "\\\\endhead\\n\\n\\\\endfoot\\n",
+          paste0("\\\\endhead\n", # "\\\\midrule\n",
+                 fn_regexp, "\n\\\\endfoot\n"),
+          out)
+        out <- sub(
+          "\\\\endlastfoot",
+          paste0(fn_regexp, "\n\\\\endlastfoot\n"),
+          out)
+      }
     }
   }
 

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -28,7 +28,7 @@
 #' specifying large font size with the kable_styling() (e.g. ideal font for headers
 #' and table content with small font in footnotes).
 #' @param show_every_page T/F To make footnotes print at bottom of all pages for
-#' long tables.  Only applies to pdf threeparttables.
+#' long tables.  Only applies to pdf longtables.
 #' @param general_title Section header for general footnotes. Default is
 #' "Note: ".
 #' @param number_title Section header for number footnotes. Default is "".

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -354,10 +354,19 @@ footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
                  fn_regexp, "\n\\\\endlastfoot\n"),
           out)
       } else {
-        out <- sub(
-          "\\\\endhead\\n\\n\\\\endfoot\\n",
-          paste0("\\\\endhead\n\\\\midrule\n", fn_regexp, "\n\\\\endfoot\n"),
-          out)
+        if (grepl(  # no repeat_header_continued in kable_styling
+          "\\\\endhead\\n\\n\\\\endfoot",
+          out)) {
+          out <- sub(
+            "\\\\endhead\\n\\n\\\\endfoot",
+            paste0("\\\\endhead\n\\\\midrule\n", fn_regexp, "\n\\\\endfoot"),
+            out)
+        } else {  # repeat_header_continued in kable_styling
+          out <- sub(
+            "\\\\endfoot",
+            paste0(fn_regexp, "\n\\\\endfoot"),
+            out)
+        }
         out <- sub(
           "\\\\endlastfoot",
           paste0(fn_regexp, "\n\\\\endlastfoot\n"),

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -342,29 +342,21 @@ footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
       longtable_start <- sub(".*\\\\begin\\{longtable\\}",
                              "\\\\begin\\{longtable\\}", out)
       longtable_text <- sub("\n.*", "", longtable_start)
-
-      if(!table_info$booktabs){
-        out <- sub(longtable_text,
-                   paste(longtable_text, "\n", fn_text, "\n\\endfoot\n"),
-                   out, fixed = TRUE)
-      } else {
-        out <- sub(longtable_text,
-                   paste(longtable_text, fn_text, "\n\\endfoot\n"),
-                   out, fixed = TRUE)
-      }
+      out <- sub(longtable_text,
+                 paste(longtable_text, fn_text, "\n\\endfoot\n"),
+                 out, fixed = TRUE)
     } else {
       if(!table_info$booktabs){
         out <- sub(
           "\\\\endhead\\n",
           paste0("\\\\endhead\n",
-            fn_regexp, "\n\\\\endfoot\n",
-            fn_regexp, "\n\\\\endlastfoot\n"),
+                 fn_regexp, "\n\\\\endfoot\n",
+                 fn_regexp, "\n\\\\endlastfoot\n"),
           out)
       } else {
         out <- sub(
           "\\\\endhead\\n\\n\\\\endfoot\\n",
-          paste0("\\\\endhead\n\\\\midrule\n", fn_regexp,
-                 "\n\\\\endfoot\n"),
+          paste0("\\\\endhead\n\\\\midrule\n", fn_regexp, "\n\\\\endfoot\n"),
           out)
         out <- sub(
           "\\\\endlastfoot",

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -28,7 +28,8 @@
 #' specifying large font size with the kable_styling() (e.g. ideal font for headers
 #' and table content with small font in footnotes).
 #' @param show_every_page T/F To make footnotes print at bottom of all pages for
-#' long tables.
+#' long tables, only works with threeparttables = TRUE and
+#' kable_styling(latex_options = "repeat").
 #' @param general_title Section header for general footnotes. Default is
 #' "Note: ".
 #' @param number_title Section header for number footnotes. Default is "".
@@ -322,17 +323,16 @@ footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
                  out)
     }
   }
-  if (show_every_page) {
+  # browser()
+  if (table_info$tabular == "longtable" & threeparttable &
+      show_every_page & !is.null(table_info$repeat_header_latex)) {
     if (table_info$booktabs) {
-      out <- sub("\\\\endhead\\n\\n\\\\endfoot",
-                 "\\\\endhead\n\\\\midrule\n\\\\insertTableNotes\n\\\\endfoot",
+      out <- sub("\\\\endhead\\n\\n\\\\endfoot\\n",
+                 "\\\\endhead\n\\\\midrule\n\\\\insertTableNotes\n\\\\endfoot\n",
                  out)
     } else {
-      out <- sub("\\\\insertTableNotes\\n",
-                 "",
-                 out)
       out <- sub("\\\\endhead\\n",
-                 "\\\\endhead\n\\\\hline\n\\\\insertTableNotes\n\\\\endfoot\n",
+                 "\\\\endhead\n\\\\midrule\n\\\\insertTableNotes\n\\\\endfoot\n",
                  out)
     }
   }

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -330,9 +330,6 @@ footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
   }
 
   if (table_info$tabular == "longtable" & show_every_page) {
-    # fn_regexp <- paste(
-    #   ifelse(table_info$booktabs, "\\\\midrule", ""),
-    #   ifelse(threeparttable, "\\\\insertTableNotes", footnote_text))
     fn_regexp <- ifelse(threeparttable, "\\\\insertTableNotes",
                         footnote_text)
     fn_text <- gsub("\\\\", "\\", fn_regexp, fixed = TRUE)

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -330,11 +330,12 @@ footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
   }
 
   if (table_info$tabular == "longtable" & show_every_page) {
-    fn_regexp <- paste0(
-      ifelse(table_info$booktabs, "\\\\midrule", ""),
-      ifelse(threeparttable, "\\\\insertTableNotes", footnote_text))
+    # fn_regexp <- paste(
+    #   ifelse(table_info$booktabs, "\\\\midrule", ""),
+    #   ifelse(threeparttable, "\\\\insertTableNotes", footnote_text))
+    fn_regexp <- ifelse(threeparttable, "\\\\insertTableNotes",
+                        footnote_text)
     fn_text <- gsub("\\\\", "\\", fn_regexp, fixed = TRUE)
-
     if(is.null(table_info$repeat_header_latex)) {
       # need full \begin{longtable} command
       # table_info valign2 ok but align missing vertical lines
@@ -343,34 +344,27 @@ footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
       longtable_text <- sub("\n.*", "", longtable_start)
 
       if(!table_info$booktabs){
-        print(paste("basic and not bt:")) #, grepl(longtable_text, out)))
         out <- sub(longtable_text,
-                   paste(longtable_text, "\n",
-                         fn_text, "\n\\endfoot\n"),
+                   paste(longtable_text, "\n", fn_text, "\n\\endfoot\n"),
                    out, fixed = TRUE)
       } else {
-        print(paste("basic and bt")) #, grepl(longtable_text, out)))
         out <- sub(longtable_text,
-                   paste(longtable_text, # "\n\\midrule\n",
-                         fn_text, "\n\\endfoot\n"),
+                   paste(longtable_text, fn_text, "\n\\endfoot\n"),
                    out, fixed = TRUE)
       }
     } else {
       if(!table_info$booktabs){
-        print(paste("repeat and not bt", grepl("\\\\endhead\\n", out)))
         out <- sub(
           "\\\\endhead\\n",
-          paste0(
-            "\\\\endhead\n",
+          paste0("\\\\endhead\n",
             fn_regexp, "\n\\\\endfoot\n",
             fn_regexp, "\n\\\\endlastfoot\n"),
           out)
       } else {
-        print(paste("repeat and bt", grepl("\\\\endhead\\n\\n\\\\endfoot\\n", out)))
         out <- sub(
           "\\\\endhead\\n\\n\\\\endfoot\\n",
-          paste0("\\\\endhead\n", # "\\\\midrule\n",
-                 fn_regexp, "\n\\\\endfoot\n"),
+          paste0("\\\\endhead\n\\\\midrule\n", fn_regexp,
+                 "\n\\\\endfoot\n"),
           out)
         out <- sub(
           "\\\\endlastfoot",

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -269,8 +269,11 @@ html_tfoot_maker_ <- function(ft_contents, ft_title, ft_type, ft_chunk) {
 # LaTeX
 footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
                            threeparttable, fixed_small_size, show_every_page) {
+  fn_regexp <- fn_text <- longtable_start <- longtable_text <- NULL
+
   table_info <- magic_mirror(kable_input)
   out <- solve_enc(kable_input)
+  fn_regexp <- fn_text <- longtable_start <- longtable_text <- NULL
 
   footnote_text <- latex_tfoot_maker(footnote_table, footnote_as_chunk,
                                      table_info$ncol, threeparttable)

--- a/man/collapse_rows.Rd
+++ b/man/collapse_rows.Rd
@@ -34,8 +34,8 @@ Choose from \code{full}, \code{major}, \code{none}, \code{custom} and \code{line
 
 \item{row_group_label_position}{Option controlling positions of row group
 labels. Choose from \code{identity}, \code{stack}, or \code{first} -- the latter behaves
-like \code{identity} when \code{row_group_label_position} is \code{top} but without using
-the multirow package.}
+like \code{identity} when \code{valign} is \code{top} but without using the multirow
+package.}
 
 \item{custom_latex_hline}{Numeric column positions whose collapsed rows will
 be separated by hlines.}

--- a/man/footnote.Rd
+++ b/man/footnote.Rd
@@ -15,6 +15,7 @@ footnote(
   escape = TRUE,
   threeparttable = FALSE,
   fixed_small_size = FALSE,
+  show_every_page = FALSE,
   general_title = "Note: ",
   number_title = "",
   alphabet_title = "",
@@ -55,6 +56,9 @@ long paragraph of footnotes.}
 \item{fixed_small_size}{T/F When you want to keep the footnote small after
 specifying large font size with the kable_styling() (e.g. ideal font for headers
 and table content with small font in footnotes).}
+
+\item{show_every_page}{T/F To make footnotes print at bottom of all pages for
+long tables.  Only applies to pdf longtables.}
 
 \item{general_title}{Section header for general footnotes. Default is
 "Note: ".}

--- a/man/kableExtra-package.Rd
+++ b/man/kableExtra-package.Rd
@@ -66,4 +66,35 @@ align the table, \code{kable_styling(kable(...), position = "left")} will work
 in both HTML and PDF.
 }
 
+\seealso{
+Useful links:
+\itemize{
+  \item \url{http://haozhu233.github.io/kableExtra/}
+  \item \url{https://github.com/haozhu233/kableExtra}
+  \item Report bugs at \url{https://github.com/haozhu233/kableExtra/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Hao Zhu \email{haozhu233@gmail.com} (\href{https://orcid.org/0000-0002-3386-6076}{ORCID})
+
+Other contributors:
+\itemize{
+  \item Thomas Travison [contributor]
+  \item Timothy Tsai [contributor]
+  \item Will Beasley \email{wibeasley@hotmail.com} [contributor]
+  \item Yihui Xie \email{xie@yihui.name} [contributor]
+  \item GuangChuang Yu \email{guangchuangyu@gmail.com} [contributor]
+  \item Stéphane Laurent [contributor]
+  \item Rob Shepherd [contributor]
+  \item Yoni Sidi [contributor]
+  \item Brian Salzer [contributor]
+  \item George Gui [contributor]
+  \item Yeliang Fan [contributor]
+  \item Duncan Murdoch [contributor]
+  \item Vincent Arel-Bundock [contributor]
+  \item Bill Evans [contributor]
+}
+
+}
 \keyword{package}

--- a/man/kbl.Rd
+++ b/man/kbl.Rd
@@ -65,11 +65,12 @@ are left-aligned. If \code{length(align) == 1L}, the string will be
 expanded to a vector of individual letters, e.g. \code{'clc'} becomes
 \code{c('c', 'l', 'c')}, unless the output format is LaTeX.}
 
-\item{caption}{The table caption.}
+\item{caption}{The table caption. By default, it is retrieved from the chunk
+option \code{tab.cap}.}
 
 \item{label}{The table reference label. By default, the label is obtained
-from \code{knitr::\link[knitr]{opts_current}$get('label')}. To disable the label,
-use \code{label = NA}.}
+from \code{knitr::\link[knitr]{opts_current}$get('label')} (i.e., the current
+chunk label). To disable the label, use \code{label = NA}.}
 
 \item{format.args}{A list of arguments to be passed to \code{\link{format}()}
 to format table values, e.g. \code{list(big.mark = ',')}.}

--- a/tests/visual_tests/footnote_latex_perm.Rmd
+++ b/tests/visual_tests/footnote_latex_perm.Rmd
@@ -22,22 +22,23 @@ names(dat)[3] <- paste0(names(dat)[3], footnote_marker_number(1))
 
 ```{r permute, results='asis'}
 # Define new environment
-is_every <- c(FALSE, TRUE)
-latex_opt <- c("basic", "repeat_header")
+latex_opt <- c("basic", "repeat_header")  # test basic to show doesn't cause trouble
 is_bt <- c(FALSE, TRUE)
 is_tpt <- c(FALSE, TRUE)
-cap_opt <- c(NA, "Include a caption")  # if NA use default NULL
+is_cont_at_btm <- c(FALSE, TRUE)  # only shows for booktabs
+is_every <- c(FALSE, TRUE)
 
 child_env <- new.env()
-for(i_every in seq_along(is_every)){
-  for(i_latex_opt in seq_along(latex_opt)){
-    for(i_bt in seq_along(is_bt)){
-      for(i_tpt in seq_along(is_tpt)){
-        for(i_cap_opt in seq_along(cap_opt)){
-          child_env$i_tpt <- i_tpt
+for(i_latex_opt in seq_along(latex_opt)){
+  for(i_bt in seq_along(is_bt)){
+    for(i_tpt in seq_along(is_tpt)){
+      for(i_is_cont_at_btm in seq_along(is_cont_at_btm)){
+        for(i_every in seq_along(is_every)){
           child_env$i_latex_opt <- i_latex_opt
-          child_env$i_cap_opt <- i_cap_opt
-          child_env$i_bt <- i_bt
+          child_env$i_bt <- i_bt          
+          child_env$i_tpt <- i_tpt
+          child_env$i_is_cont_at_btm <- i_is_cont_at_btm
+          child_env$i_every <- i_every          
           
           # knit the document and save the character output to an object
           res <- knitr::knit_child(

--- a/tests/visual_tests/footnote_latex_perm.Rmd
+++ b/tests/visual_tests/footnote_latex_perm.Rmd
@@ -28,11 +28,13 @@ cap_opt <- c(NA, "Include a caption")  # if NA use default NULL
 is_bt <- c(FALSE, TRUE)
 
 child_env <- new.env()
-for(i_every in seq_along(is_every)){
-  for(i_tpt in seq_along(is_tpt)){
-    for(i_latex_opt in seq_along(latex_opt)){
-      for(i_cap_opt in seq_along(cap_opt)){
-        for(i_bt in seq_along(is_bt)){
+# for(i_every in seq_along(is_every)){
+for(i_every in 2){
+  for(i_latex_opt in seq_along(latex_opt)){
+    for(i_bt in seq_along(is_bt)){
+      for(i_tpt in seq_along(is_tpt)){
+        # for(i_cap_opt in seq_along(cap_opt)){
+        for(i_cap_opt in 2){
           child_env$i_tpt <- i_tpt
           child_env$i_latex_opt <- i_latex_opt
           child_env$i_cap_opt <- i_cap_opt

--- a/tests/visual_tests/footnote_latex_perm.Rmd
+++ b/tests/visual_tests/footnote_latex_perm.Rmd
@@ -22,19 +22,17 @@ names(dat)[3] <- paste0(names(dat)[3], "\\tnote{1}")
 ```{r permute, results='asis'}
 # Define new environment
 is_every <- c(FALSE, TRUE)
-is_tpt <- c(FALSE, TRUE)
 latex_opt <- c("basic", "repeat_header")
-cap_opt <- c(NA, "Include a caption")  # if NA use default NULL
 is_bt <- c(FALSE, TRUE)
+is_tpt <- c(FALSE, TRUE)
+cap_opt <- c(NA, "Include a caption")  # if NA use default NULL
 
 child_env <- new.env()
-# for(i_every in seq_along(is_every)){
-for(i_every in 2){
+for(i_every in seq_along(is_every)){
   for(i_latex_opt in seq_along(latex_opt)){
     for(i_bt in seq_along(is_bt)){
       for(i_tpt in seq_along(is_tpt)){
-        # for(i_cap_opt in seq_along(cap_opt)){
-        for(i_cap_opt in 2){
+        for(i_cap_opt in seq_along(cap_opt)){
           child_env$i_tpt <- i_tpt
           child_env$i_latex_opt <- i_latex_opt
           child_env$i_cap_opt <- i_cap_opt

--- a/tests/visual_tests/footnote_latex_perm.Rmd
+++ b/tests/visual_tests/footnote_latex_perm.Rmd
@@ -1,0 +1,56 @@
+---
+title: "footnote_perm"
+author: "Byron"
+date: "9/11/2024"
+output: pdf_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = !TRUE)
+devtools::load_all()
+# library(kableExtra)
+
+dat <- data.frame(
+  Col1 = LETTERS[rep(1:26, each = 2)],
+  Col2 = letters[rep(1:26, 2)],
+  n = 0:51
+)
+names(dat)[3] <- paste0(names(dat)[3], "\\tnote{1}")
+```
+
+
+```{r permute, results='asis'}
+# Define new environment
+is_every <- c(FALSE, TRUE)
+is_tpt <- c(FALSE, TRUE)
+latex_opt <- c("basic", "repeat_header")
+cap_opt <- c(NA, "Include a caption")  # if NA use default NULL
+is_bt <- c(FALSE, TRUE)
+
+child_env <- new.env()
+for(i_every in seq_along(is_every)){
+  for(i_tpt in seq_along(is_tpt)){
+    for(i_latex_opt in seq_along(latex_opt)){
+      for(i_cap_opt in seq_along(cap_opt)){
+        for(i_bt in seq_along(is_bt)){
+          child_env$i_tpt <- i_tpt
+          child_env$i_latex_opt <- i_latex_opt
+          child_env$i_cap_opt <- i_cap_opt
+          child_env$i_bt <- i_bt
+          
+          # knit the document and save the character output to an object
+          res <- knitr::knit_child(
+            "footnote_latex_perm_child.Rmd",
+            envir = child_env,
+            quiet = TRUE
+          )
+          
+          # Cat the object to make it render in your main document
+          cat(res, sep = "\n")
+        }
+      }
+    }
+  }
+}
+```
+

--- a/tests/visual_tests/footnote_latex_perm.Rmd
+++ b/tests/visual_tests/footnote_latex_perm.Rmd
@@ -15,7 +15,8 @@ dat <- data.frame(
   Col2 = letters[rep(1:26, 2)],
   n = 0:51
 )
-names(dat)[3] <- paste0(names(dat)[3], "\\tnote{1}")
+# "\\tnote{1}  is TPT only
+names(dat)[3] <- paste0(names(dat)[3], footnote_marker_number(1))
 ```
 
 

--- a/tests/visual_tests/footnote_latex_perm_child.Rmd
+++ b/tests/visual_tests/footnote_latex_perm_child.Rmd
@@ -35,7 +35,7 @@ a_kbl |>
   kable_styling(
     latex_options = latex_opt[i_latex_opt]) |>
   footnote(
-    number = c("footnote text"),
+    number = c("footnote on colname"),
     threeparttable = is_tpt[i_tpt],
     show_every_page = is_every[i_every])
 ```

--- a/tests/visual_tests/footnote_latex_perm_child.Rmd
+++ b/tests/visual_tests/footnote_latex_perm_child.Rmd
@@ -3,37 +3,30 @@ output:
   pdf_document
 ---
 ```{r results='asis'}
-# i_tpt <- i_latex_opt <- i_cap_opt <- i_bt <- 1
-use_lab <- paste("lab", i_every, i_latex_opt, i_bt, i_tpt, 
-                 i_cap_opt, sep = "-")
+# i_latex_opt <- i_bt <- i_tpt <- i_is_cont_at_btm <- i_every <- 2
+use_lab <- paste("lab", i_latex_opt, i_bt, i_tpt, 
+                 i_is_cont_at_btm, i_every, sep = "-")
 ```
 
 ### `r use_lab`
 Permutations
 \vspace{-10pt}
 
-* every page: `r is_every[i_every]`
 * latex option: `r latex_opt[i_latex_opt]`
 * booktab: `r is_bt[i_bt]`
 * TPT: `r is_tpt[i_tpt]`
-* caption: `r cap_opt[i_cap_opt]`
+* continue on bottom: `r is_cont_at_btm[i_is_cont_at_btm]`
+* every page: `r is_every[i_every]`
 
 
 ```{r results='asis'}
-if (i_cap_opt == 1) {
-  a_kbl <- dat |>
-    kbl(format = "latex", 
-        label = use_lab, escape = FALSE, 
-        booktabs = is_bt[i_bt], longtable = TRUE)
-} else {
-  a_kbl <- dat |> 
-    kbl(format = "latex", caption = cap_opt[i_cap_opt], 
-        label = use_lab, escape = FALSE, 
-        booktabs = is_bt[i_bt], longtable = TRUE) 
-}
-a_kbl |>
+dat |>
+  kbl(format = "latex", caption = "Table caption",
+      label = use_lab, escape = FALSE, 
+      booktabs = is_bt[i_bt], longtable = TRUE) |>
   kable_styling(
-    latex_options = latex_opt[i_latex_opt]) |>
+    latex_options = latex_opt[i_latex_opt],
+    repeat_header_continued = is_cont_at_btm[i_is_cont_at_btm]) |>
   footnote(
     number = c("footnote on colname"),
     threeparttable = is_tpt[i_tpt],

--- a/tests/visual_tests/footnote_latex_perm_child.Rmd
+++ b/tests/visual_tests/footnote_latex_perm_child.Rmd
@@ -4,8 +4,8 @@ output:
 ---
 ```{r results='asis'}
 # i_tpt <- i_latex_opt <- i_cap_opt <- i_bt <- 1
-use_lab <- paste("lab", i_every, i_tpt, i_latex_opt, i_cap_opt, 
-                 i_bt, sep = "-")
+use_lab <- paste("lab", i_every, i_latex_opt, i_bt, i_tpt, 
+                 i_cap_opt, sep = "-")
 ```
 
 ### `r use_lab`
@@ -13,10 +13,10 @@ Permutations
 \vspace{-10pt}
 
 * every page: `r is_every[i_every]`
-* TPT: `r is_tpt[i_tpt]`
 * latex option: `r latex_opt[i_latex_opt]`
-* caption: `r cap_opt[i_cap_opt]`
 * booktab: `r is_bt[i_bt]`
+* TPT: `r is_tpt[i_tpt]`
+* caption: `r cap_opt[i_cap_opt]`
 
 
 ```{r results='asis'}

--- a/tests/visual_tests/footnote_latex_perm_child.Rmd
+++ b/tests/visual_tests/footnote_latex_perm_child.Rmd
@@ -1,0 +1,43 @@
+---
+output: 
+  pdf_document
+---
+```{r results='asis'}
+# i_tpt <- i_latex_opt <- i_cap_opt <- i_bt <- 1
+use_lab <- paste("lab", i_every, i_tpt, i_latex_opt, i_cap_opt, 
+                 i_bt, sep = "-")
+```
+
+### `r use_lab`
+Permutations
+\vspace{-10pt}
+
+* every page: `r is_every[i_every]`
+* TPT: `r is_tpt[i_tpt]`
+* latex option: `r latex_opt[i_latex_opt]`
+* caption: `r cap_opt[i_cap_opt]`
+* booktab: `r is_bt[i_bt]`
+
+
+```{r results='asis'}
+if (i_cap_opt == 1) {
+  a_kbl <- dat |>
+    kbl(format = "latex", 
+        label = use_lab, escape = FALSE, 
+        booktabs = is_bt[i_bt], longtable = TRUE)
+} else {
+  a_kbl <- dat |> 
+    kbl(format = "latex", caption = cap_opt[i_cap_opt], 
+        label = use_lab, escape = FALSE, 
+        booktabs = is_bt[i_bt], longtable = TRUE) 
+}
+a_kbl |>
+  kable_styling(
+    latex_options = latex_opt[i_latex_opt]) |>
+  footnote(
+    number = c("footnote text"),
+    threeparttable = is_tpt[i_tpt],
+    show_every_page = is_every[i_every])
+```
+
+\clearpage


### PR DESCRIPTION
This resolves issue [#858](https://github.com/haozhu233/kableExtra/issues/858) show footnotes every page (with partial solution)

Added argument `show_every_page` to `footnote()`.  
If `show_every_page = TRUE` then table footnotes will show at the bottom of all pages for longtable pdf's.  
Code works for all permutations of `booktabs = T`/`F`, `three_part_table = T`/`F`, `latex_options = "basic"`/`"repeat_header"`, and `repeat_header_continued = T`/`F`. 
Includes exhaustive testing.

Feedback welcome.