### PR TITLE
magic_mirror_latex should recognize tabularx tables.  

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kableExtra
 Type: Package
 Title: Construct Complex Table with 'kable' and Pipe Syntax
-Version: 1.4.0.5
+Version: 1.4.0.6
 Authors@R: c(
     person('Hao', 'Zhu', email = 'haozhu233@gmail.com', role = c('aut', 'cre'),
     comment = c(ORCID = '0000-0002-3386-6076')),

--- a/R/magic_mirror.R
+++ b/R/magic_mirror.R
@@ -42,8 +42,14 @@ magic_mirror_latex <- function(kable_input){
   # Tabular
   table_info$tabular <- ifelse(
     grepl("\\\\begin\\{tabular\\}", kable_input),
-    "tabular", "longtable"
+    "tabular",
+    ifelse(
+      grepl("\\\\begin\\{tabularx\\}", kable_input),
+      "tabularx",
+      "longtable"
+    )
   )
+
   # Booktabs
   table_info$booktabs <- grepl(toprule_regexp, kable_input)
   # Align

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,4 +1,4 @@
-kableExtra 1.4.0.5
+kableExtra 1.4.0.6
 --------------------------------------------------------------------------------
 
 Bug Fixes:
@@ -14,6 +14,8 @@ containing LaTeX code to be rendered incorrectly in LaTeX
 documents (#836).
 * Fixed a bug in `save_kable_latex()` which left the user
 in the wrong directory if an error occurred (#865).
+* Fixed a bug in `magic_mirror_latex()` which
+stopped it from working with `tabularx` tables (#861).
 
 
 kableExtra 1.4.0

--- a/tests/testthat/_snaps/bugfix.md
+++ b/tests/testthat/_snaps/bugfix.md
@@ -1,3 +1,82 @@
+# Issue #861:  pack_rows with tabularx
+
+    Code
+      kbl(mtcars, format = "latex", tabular = "tabularx", valign = "{\\textwidth}") %>%
+        kableExtra::pack_rows("XXX", 1, 2)
+    Output
+      
+      \begin{tabularx}{\textwidth}{l|r|r|r|r|r|r|r|r|r|r|r}
+      \hline
+        & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\
+      \hline
+      \multicolumn{12}{l}{\textbf{XXX}}\\
+      \hline
+      \hspace{1em}Mazda RX4 & 21.0 & 6 & 160.0 & 110 & 3.90 & 2.620 & 16.46 & 0 & 1 & 4 & 4\\
+      \hline
+      \hspace{1em}Mazda RX4 Wag & 21.0 & 6 & 160.0 & 110 & 3.90 & 2.875 & 17.02 & 0 & 1 & 4 & 4\\
+      \hline
+      Datsun 710 & 22.8 & 4 & 108.0 & 93 & 3.85 & 2.320 & 18.61 & 1 & 1 & 4 & 1\\
+      \hline
+      Hornet 4 Drive & 21.4 & 6 & 258.0 & 110 & 3.08 & 3.215 & 19.44 & 1 & 0 & 3 & 1\\
+      \hline
+      Hornet Sportabout & 18.7 & 8 & 360.0 & 175 & 3.15 & 3.440 & 17.02 & 0 & 0 & 3 & 2\\
+      \hline
+      Valiant & 18.1 & 6 & 225.0 & 105 & 2.76 & 3.460 & 20.22 & 1 & 0 & 3 & 1\\
+      \hline
+      Duster 360 & 14.3 & 8 & 360.0 & 245 & 3.21 & 3.570 & 15.84 & 0 & 0 & 3 & 4\\
+      \hline
+      Merc 240D & 24.4 & 4 & 146.7 & 62 & 3.69 & 3.190 & 20.00 & 1 & 0 & 4 & 2\\
+      \hline
+      Merc 230 & 22.8 & 4 & 140.8 & 95 & 3.92 & 3.150 & 22.90 & 1 & 0 & 4 & 2\\
+      \hline
+      Merc 280 & 19.2 & 6 & 167.6 & 123 & 3.92 & 3.440 & 18.30 & 1 & 0 & 4 & 4\\
+      \hline
+      Merc 280C & 17.8 & 6 & 167.6 & 123 & 3.92 & 3.440 & 18.90 & 1 & 0 & 4 & 4\\
+      \hline
+      Merc 450SE & 16.4 & 8 & 275.8 & 180 & 3.07 & 4.070 & 17.40 & 0 & 0 & 3 & 3\\
+      \hline
+      Merc 450SL & 17.3 & 8 & 275.8 & 180 & 3.07 & 3.730 & 17.60 & 0 & 0 & 3 & 3\\
+      \hline
+      Merc 450SLC & 15.2 & 8 & 275.8 & 180 & 3.07 & 3.780 & 18.00 & 0 & 0 & 3 & 3\\
+      \hline
+      Cadillac Fleetwood & 10.4 & 8 & 472.0 & 205 & 2.93 & 5.250 & 17.98 & 0 & 0 & 3 & 4\\
+      \hline
+      Lincoln Continental & 10.4 & 8 & 460.0 & 215 & 3.00 & 5.424 & 17.82 & 0 & 0 & 3 & 4\\
+      \hline
+      Chrysler Imperial & 14.7 & 8 & 440.0 & 230 & 3.23 & 5.345 & 17.42 & 0 & 0 & 3 & 4\\
+      \hline
+      Fiat 128 & 32.4 & 4 & 78.7 & 66 & 4.08 & 2.200 & 19.47 & 1 & 1 & 4 & 1\\
+      \hline
+      Honda Civic & 30.4 & 4 & 75.7 & 52 & 4.93 & 1.615 & 18.52 & 1 & 1 & 4 & 2\\
+      \hline
+      Toyota Corolla & 33.9 & 4 & 71.1 & 65 & 4.22 & 1.835 & 19.90 & 1 & 1 & 4 & 1\\
+      \hline
+      Toyota Corona & 21.5 & 4 & 120.1 & 97 & 3.70 & 2.465 & 20.01 & 1 & 0 & 3 & 1\\
+      \hline
+      Dodge Challenger & 15.5 & 8 & 318.0 & 150 & 2.76 & 3.520 & 16.87 & 0 & 0 & 3 & 2\\
+      \hline
+      AMC Javelin & 15.2 & 8 & 304.0 & 150 & 3.15 & 3.435 & 17.30 & 0 & 0 & 3 & 2\\
+      \hline
+      Camaro Z28 & 13.3 & 8 & 350.0 & 245 & 3.73 & 3.840 & 15.41 & 0 & 0 & 3 & 4\\
+      \hline
+      Pontiac Firebird & 19.2 & 8 & 400.0 & 175 & 3.08 & 3.845 & 17.05 & 0 & 0 & 3 & 2\\
+      \hline
+      Fiat X1-9 & 27.3 & 4 & 79.0 & 66 & 4.08 & 1.935 & 18.90 & 1 & 1 & 4 & 1\\
+      \hline
+      Porsche 914-2 & 26.0 & 4 & 120.3 & 91 & 4.43 & 2.140 & 16.70 & 0 & 1 & 5 & 2\\
+      \hline
+      Lotus Europa & 30.4 & 4 & 95.1 & 113 & 3.77 & 1.513 & 16.90 & 1 & 1 & 5 & 2\\
+      \hline
+      Ford Pantera L & 15.8 & 8 & 351.0 & 264 & 4.22 & 3.170 & 14.50 & 0 & 1 & 5 & 4\\
+      \hline
+      Ferrari Dino & 19.7 & 6 & 145.0 & 175 & 3.62 & 2.770 & 15.50 & 0 & 1 & 5 & 6\\
+      \hline
+      Maserati Bora & 15.0 & 8 & 301.0 & 335 & 3.54 & 3.570 & 14.60 & 0 & 1 & 5 & 8\\
+      \hline
+      Volvo 142E & 21.4 & 4 & 121.0 & 109 & 4.11 & 2.780 & 18.60 & 1 & 1 & 4 & 2\\
+      \hline
+      \end{tabularx}
+
 # Issue #836:  latex allowed in add_header_above
 
     Code

--- a/tests/testthat/test-bugfix.R
+++ b/tests/testthat/test-bugfix.R
@@ -1,3 +1,13 @@
+test_that("Issue #861:  pack_rows with tabularx", {
+  expect_snapshot(
+    kbl(mtcars, format="latex", tabular = "tabularx",
+        valign="{\\textwidth}") %>%
+      kableExtra::pack_rows("XXX", 1,2)
+
+  )
+}
+)
+
 test_that("Issue #836:  latex allowed in add_header_above", {
   expect_snapshot(
     kbl(mtcars[1:2, 1:2], col.names=NULL,


### PR DESCRIPTION
Fix for #861 found by Lorenz Thomschke.