### PR TITLE
Allow `line` to be a vector in `add_header_above`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kableExtra
 Type: Package
 Title: Construct Complex Table with 'kable' and Pipe Syntax
-Version: 1.4.0.8
+Version: 1.4.0.9
 Authors@R: c(
     person('Hao', 'Zhu', email = 'haozhu233@gmail.com', role = c('aut', 'cre'),
     comment = c(ORCID = '0000-0002-3386-6076')),

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,11 +1,13 @@
 
-kableExtra 1.4.0.8
+kableExtra 1.4.0.9
 --------------------------------------------------------------------------------
 
 New Features:
 
 * Added `show_every_page` argument to `footnote()` (#867).
 * Added `class` argument to `cell_spec()` (#871).
+* `add_header_above()` now supports specifying
+`line` as a vector (#700).
 
 Bug Fixes:
 

--- a/man/add_header_above.Rd
+++ b/man/add_header_above.Rd
@@ -73,7 +73,7 @@ options including \code{xx-small}, \code{x-small}, \code{small}, \code{medium}, 
 \item{escape}{A T/F value showing whether special characters should be
 escaped.}
 
-\item{line}{A T/F value to control whether a line will appear underneath the
+\item{line}{A T/F value/vector to control whether a line will appear underneath the
 header}
 
 \item{line_sep}{A numeric value indicating how much the midlines should be
@@ -96,7 +96,7 @@ function and adds an header row on top of it.
 }
 \examples{
 \dontrun{
-x <- knitr::kable(head(mtcars), "html")
+x <- kbl(head(mtcars), "html")
 # Add a row of header with 3 columns on the top of the table. The column
 # span for the 2nd and 3rd one are 5 & 6.
 add_header_above(x, c(" ", "Group 1" = 5, "Group 2" = 6))


### PR DESCRIPTION
 for LaTeX as well as HTML.  Fixes #700.