### PR TITLE
Get magic_mirror() to handle complex alignment specs like "p{1cm}".

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kableExtra
 Type: Package
 Title: Construct Complex Table with 'kable' and Pipe Syntax
-Version: 1.4.0.9
+Version: 1.4.0.10
 Authors@R: c(
     person('Hao', 'Zhu', email = 'haozhu233@gmail.com', role = c('aut', 'cre'),
     comment = c(ORCID = '0000-0002-3386-6076')),

--- a/R/magic_mirror.R
+++ b/R/magic_mirror.R
@@ -52,15 +52,19 @@ magic_mirror_latex <- function(kable_input){
 
   # Booktabs
   table_info$booktabs <- grepl(toprule_regexp, kable_input)
-  # Align
-  table_info$align <- gsub("\\|", "", str_match(
-    kable_input, paste0("\\\\begin\\{",
-                        table_info$tabular,"\\}.*\\{(.*?)\\}"))[2])
-  table_info$align_vector <- unlist(strsplit(table_info$align, ""))
+  # Alignment is a sequence with each element being a single letter, or a
+  # single letter followed by a measurement in braces, e.g. "p{1cm}"
+  align1 <- "[[:alpha:]](?:\\{[^{}]*\\})?\\|*"
+  align_pattern <- paste0("(?:", align1, ")*")
+  align <- str_match(kable_input,
+                     paste0("\\\\begin\\{",
+                        table_info$tabular,"\\}[^{]*\\{(", align_pattern, ")\\}"))[1,2]
+  table_info$align <- gsub("\\|", "", align)
+  table_info$align_vector <- regmatches(table_info$align, gregexpr("[[:alpha:]](\\{[^{}]*\\})?", table_info$align))[[1]]
   table_info$align_vector_origin <- table_info$align_vector
   # valign
   table_info$valign <- gsub("\\|", "", str_match(
-    kable_input, paste0("\\\\begin\\{", table_info$tabular,"\\}(.*)\\{.*?\\}"))[2])
+    kable_input, paste0("\\\\begin\\{", table_info$tabular,"\\}([^{]*)\\{.*?\\}"))[2])
   table_info$valign2 <- sub("\\[", "\\\\[", table_info$valign)
   table_info$valign2 <- sub("\\]", "\\\\]", table_info$valign2)
   table_info$valign3 <- sub("\\[", "", table_info$valign)

--- a/R/magic_mirror.R
+++ b/R/magic_mirror.R
@@ -58,7 +58,9 @@ magic_mirror_latex <- function(kable_input){
   align_pattern <- paste0("(?:", align1, ")*")
   align <- str_match(kable_input,
                      paste0("\\\\begin\\{",
-                        table_info$tabular,"\\}[^{]*\\{(", align_pattern, ")\\}"))[1,2]
+                        table_info$tabular,
+                        "\\}[^{]*(?:\\{[^{]*\\})?\\{(",
+                        align_pattern, ")\\}"))[1,2]
   table_info$align <- gsub("\\|", "", align)
   table_info$align_vector <- regmatches(table_info$align, gregexpr("[[:alpha:]](\\{[^{}]*\\})?", table_info$align))[[1]]
   table_info$align_vector_origin <- table_info$align_vector
@@ -73,7 +75,7 @@ magic_mirror_latex <- function(kable_input){
                                      table_info$valign2)
   table_info$end_tabular <- paste0("\\\\end\\{", table_info$tabular, "\\}")
   # N of columns
-  table_info$ncol <- nchar(table_info$align)
+  table_info$ncol <- length(table_info$align_vector)
   # Caption
   if (str_detect(kable_input, "caption\\[")) {
     caption_line <- str_match(kable_input, "\\\\caption(.*)\\n")[2]

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,5 +1,5 @@
 
-kableExtra 1.4.0.9
+kableExtra 1.4.0.10
 --------------------------------------------------------------------------------
 
 New Features:
@@ -24,6 +24,8 @@ documents (#836).
 in the wrong directory if an error occurred (#865).
 * Fixed a bug in `magic_mirror_latex()` which
 stopped it from working with `tabularx` tables (#861).
+* Complex alignment options like `p{1cm}` were not
+handled properly by `kable_styling()` (#876).
 
 
 kableExtra 1.4.0

--- a/tests/testthat/_snaps/bugfix.md
+++ b/tests/testthat/_snaps/bugfix.md
@@ -1,3 +1,23 @@
+# Issue #876: complex alignment
+
+    Code
+      kbl(x = mtcars[1:2, 1:2], format = "latex", align = rep("p{2cm}", 2)) %>%
+        kable_styling(latex_options = "scale_down")
+    Output
+      \begin{table}
+      \centering
+      \resizebox{\ifdim\width>\linewidth\linewidth\else\width\fi}{!}{
+      \begin{tabular}[t]{l|p{2cm}|p{2cm}}
+      \hline
+        & mpg & cyl\\
+      \hline
+      Mazda RX4 & 21 & 6\\
+      \hline
+      Mazda RX4 Wag & 21 & 6\\
+      \hline
+      \end{tabular}}
+      \end{table}
+
 # Issue #861:  pack_rows with tabularx
 
     Code

--- a/tests/testthat/_snaps/row_spec.md
+++ b/tests/testthat/_snaps/row_spec.md
@@ -94,7 +94,7 @@
       1 & 4\\
       2 & 5\\
       3 & 6\\
-      \midrule\\
+      \midrule
       4 & 7\\
       \bottomrule
       \end{tabular}
@@ -147,7 +147,7 @@
       \begin{tabular}[t]{>{\centering\arraybackslash}p{5em}cc}
       \toprule
       C2 & C3 & C4\\
-      \rowcolor{gray!6}\\
+      \rowcolor{gray!6}
       \midrule
        & 1 & 0\\
       
@@ -167,25 +167,25 @@
        & 6 & 0\\
       
       \rowcolor{gray!6}
-      \multirow{-7}{5em}{\centering\arraybackslash \textbf{c}} & 7 & 1\\
+      \multirow{-7}{5em}[\normalbaselineskip]{\centering\arraybackslash \textbf{c}} & 7 & 1\\
       
        & 8 & 0\\
       
        & 9 & 1\\
       
-      \multirow{-3}{5em}{\centering\arraybackslash \textbf{d}} & 10 & 0\\
+      \multirow{-3}{5em}[\normalbaselineskip]{\centering\arraybackslash \textbf{d}} & 10 & 0\\
       
       \rowcolor{gray!6}
        & 11 & 1\\
       
       \rowcolor{gray!6}
-      \multirow{-2}{5em}{\centering\arraybackslash \textbf{c}} & 12 & 1\\
+      \multirow{-2}{5em}[\normalbaselineskip]{\centering\arraybackslash \textbf{c}} & 12 & 1\\
       
        & 13 & 0\\
       
        & 14 & 0\\
       
-      \multirow{-3}{5em}{\centering\arraybackslash \textbf{d}} & 15 & 1\\
+      \multirow{-3}{5em}[\normalbaselineskip]{\centering\arraybackslash \textbf{d}} & 15 & 1\\
       \bottomrule
       \end{tabular}
 

--- a/tests/testthat/test-bugfix.R
+++ b/tests/testthat/test-bugfix.R
@@ -1,3 +1,13 @@
+test_that("Issue #876: complex alignment", {
+  expect_snapshot(
+    kbl(x = mtcars[1:2,1:2],
+        format = "latex",
+        align = rep("p{2cm}",2)) %>%
+      kable_styling(latex_options = "scale_down")
+  )
+})
+
+
 test_that("Issue #861:  pack_rows with tabularx", {
   expect_snapshot(
     kbl(mtcars, format="latex", tabular = "tabularx",


### PR DESCRIPTION
Fixes #876.  Note that `add_header_above()` still requires simple alignment options.