### PR TITLE
Allow `align = "p{2cm}"` and similar in `add_header_above()` 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kableExtra
 Type: Package
 Title: Construct Complex Table with 'kable' and Pipe Syntax
-Version: 1.4.0.10
+Version: 1.4.0.11
 Authors@R: c(
     person('Hao', 'Zhu', email = 'haozhu233@gmail.com', role = c('aut', 'cre'),
     comment = c(ORCID = '0000-0002-3386-6076')),

--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -23,8 +23,11 @@
 #' @param strikeout A T/F value to control whether the text of the selected row
 #' need to be struck out.
 #' @param align A character string for cell alignment. For HTML, possible values could
-#' be `l`, `c`, `r` plus `left`, `center`, `right`, `justify`, `initial` and `inherit`
-#' while for LaTeX, you can only choose from `l`, `c` & `r`.
+#' be `l`, `c`, `r` plus `left`, `center`, `right`, `justify`, `initial` and `inherit`.  All
+#' legal values should be accepted for LaTeX, e.g.
+#' `l`, `c`, `r`, `p{2cm}`, but the more exotic ones
+#' may cause problems.  If so, please post a bug
+#' report!
 #' @param color A character string/vector for text color. Here please pay
 #' attention to the differences in color codes between HTML and LaTeX.
 #' @param background A character string/vector for background color. Here please
@@ -320,8 +323,6 @@ pdfTable_add_header_above <- function(kable_input, header, bold, italic,
     # because we need the regexp pattern.
     header$header <- gsub("\\\\", "\\\\\\\\", header$header)
   }
-
-  align <- vapply(align, match.arg, 'a', choices = c("l", "c", "r"))
 
   hline_type <- switch(table_info$booktabs + 1, "(\\\\hline)", toprule_regexp)
   new_header_split <- pdfTable_new_header_generator(

--- a/R/linebreak.R
+++ b/R/linebreak.R
@@ -4,19 +4,23 @@
 #' can have linebreaks in their table
 #'
 #' @param x A character vector
-#' @param align Choose from "l", "c" or "r".  Defaults to "l".
+#' @param align Alignment of the text
 #' @param double_escape Whether special character should be double escaped.
 #' Default is FALSE.
 #' @param linebreaker Symbol for linebreaks to replace. Default is `\n`.
+#' @details
+#' Not all `align` settings are supported, but
+#' simple ones such as `l`, `c`, `r` should be fine.
+#' More exotic ones like `p{3cm}` should work too,
+#' but may not if they are too complicated.
+#'
 #'
 #' @export
-linebreak <- function(x, align = c("l", "c", "r"), double_escape = F,
+linebreak <- function(x, align = "l", double_escape = F,
                       linebreaker = "\n") {
   if (is.numeric(x) | is.logical(x)) return(x)
   x <- as.character(x)
-  if (missing(align))
-    align <- "l"
-  align <- vapply(align, match.arg, 'a', choices = c("l", "c", "r"))
+
   if (double_escape) {
     ifelse(str_detect(x, linebreaker),
            paste0("\\\\makecell[", align, "]{",

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,5 +1,5 @@
 
-kableExtra 1.4.0.10
+kableExtra 1.4.0.11
 --------------------------------------------------------------------------------
 
 New Features:
@@ -8,6 +8,8 @@ New Features:
 * Added `class` argument to `cell_spec()` (#871).
 * `add_header_above()` now supports specifying
 `line` as a vector (#700).
+* `add_header_above()` and `linebreak()` now accept more exotic 
+`align` specifications, e.g. `p{2cm}`.
 
 Bug Fixes:
 

--- a/man/add_header_above.Rd
+++ b/man/add_header_above.Rd
@@ -53,8 +53,11 @@ need to be underlined}
 need to be struck out.}
 
 \item{align}{A character string for cell alignment. For HTML, possible values could
-be \code{l}, \code{c}, \code{r} plus \code{left}, \code{center}, \code{right}, \code{justify}, \code{initial} and \code{inherit}
-while for LaTeX, you can only choose from \code{l}, \code{c} & \code{r}.}
+be \code{l}, \code{c}, \code{r} plus \code{left}, \code{center}, \code{right}, \code{justify}, \code{initial} and \code{inherit}.  All
+legal values should be accepted for LaTeX, e.g.
+\code{l}, \code{c}, \code{r}, \verb{p\{2cm\}}, but the more exotic ones
+may cause problems.  If so, please post a bug
+report!}
 
 \item{color}{A character string/vector for text color. Here please pay
 attention to the differences in color codes between HTML and LaTeX.}

--- a/man/linebreak.Rd
+++ b/man/linebreak.Rd
@@ -4,12 +4,12 @@
 \alias{linebreak}
 \title{Make linebreak in LaTeX Table cells}
 \usage{
-linebreak(x, align = c("l", "c", "r"), double_escape = F, linebreaker = "\\n")
+linebreak(x, align = "l", double_escape = F, linebreaker = "\\n")
 }
 \arguments{
 \item{x}{A character vector}
 
-\item{align}{Choose from "l", "c" or "r".  Defaults to "l".}
+\item{align}{Alignment of the text}
 
 \item{double_escape}{Whether special character should be double escaped.
 Default is FALSE.}
@@ -19,4 +19,10 @@ Default is FALSE.}
 \description{
 This function generates LaTeX code of \code{makecell} so that users
 can have linebreaks in their table
+}
+\details{
+Not all \code{align} settings are supported, but
+simple ones such as \code{l}, \code{c}, \code{r} should be fine.
+More exotic ones like \verb{p\{3cm\}} should work too,
+but may not if they are too complicated.
 }

--- a/tests/testthat/_snaps/add_header_above.md
+++ b/tests/testthat/_snaps/add_header_above.md
@@ -1,0 +1,22 @@
+# add_header_above accepts p{3cm}
+
+    Code
+      kbl(mtcars[1:3, 1:3], "latex") %>% add_header_above(c(" ",
+        `This is a very long header that will need to be wrapped` = 3), align = c("l",
+        "p{3cm}"))
+    Output
+      
+      \begin{tabular}[t]{l|r|r|r}
+      \hline
+      \multicolumn{1}{l|}{ } & \multicolumn{3}{p{3cm}}{This is a very long header that will need to be wrapped} \\
+      \cline{2-4}
+        & mpg & cyl & disp\\
+      \hline
+      Mazda RX4 & 21.0 & 6 & 160\\
+      \hline
+      Mazda RX4 Wag & 21.0 & 6 & 160\\
+      \hline
+      Datsun 710 & 22.8 & 4 & 108\\
+      \hline
+      \end{tabular}
+

--- a/tests/testthat/test-add_header_above.R
+++ b/tests/testthat/test-add_header_above.R
@@ -1,0 +1,9 @@
+test_that("add_header_above accepts p{3cm}", {
+  expect_snapshot(
+    kbl(
+      mtcars[1:3, 1:3], 'latex'
+    ) %>%
+      add_header_above(c(' ',
+                       'This is a very long header that will need to be wrapped' = 3),
+                     align = c('l', 'p{3cm}')))
+})


### PR DESCRIPTION
and `linebreak()`.