### PR TITLE
Add varwidth as LaTeX package option when saving to image

### DIFF
--- a/R/save_kable.R
+++ b/R/save_kable.R
@@ -232,7 +232,7 @@ save_kable_latex <- function(x, file, latex_header_includes, keep_tex, density) 
   }
 
   temp_tex <- c(
-    "\\documentclass[border=1mm]{standalone}",
+    "\\documentclass[border=1mm,varwidth]{standalone}",
     "\\usepackage{amssymb, amsmath}",
     latex_pkg_list(),
     "\\usepackage{graphicx}",


### PR DESCRIPTION
When the LaTeX table has a caption, save_kable() throws an error. Adding the varwidth option solves this issue.

It fixes issue #897 with the help of this [TeX Stack Exchange post](https://tex.stackexchange.com/questions/597895/somethings-wrong-perhaps-a-missing-item-begintable-even-with-begintable).