### PR TITLE
Resolve `xfun::attr()` conflict/dependency

### DIFF
--- a/R/add_footnote.R
+++ b/R/add_footnote.R
@@ -40,7 +40,7 @@ add_footnote <- function(input, label = NULL,
     ids.intable <- ids
   } else {
     if (notation == "symbol") {
-      notation <- paste0(notation, ".", attr(input, "format"))
+      notation <- paste0(notation, ".", base::attr(input, "format", exact = TRUE))
     }
 
     ids.ops <- read.csv(system.file("symbol_index.csv", package = "kableExtra"))
@@ -72,7 +72,7 @@ add_footnote <- function(input, label = NULL,
   # markdown doesn't support complex table formats but this solution
   # should be able to satisfy people who don't want to spend extra
   # time to define their `kable` format.
-  if (!attr(input, "format") %in% c("html", "latex")) {
+  if (!base::attr(input, "format", exact = TRUE) %in% c("html", "latex")) {
     if (notation == "none")
       ids.innote <- ids.intable  # issue #672
     else
@@ -104,7 +104,7 @@ add_footnote <- function(input, label = NULL,
   }
 
   # LaTeX Tables --------------------------------
-  if (attr(input, "format") == "latex") {
+  if (base::attr(input, "format", exact = TRUE) == "latex") {
     # Clean the entry for labels
     if (escape) {
       label <- escape_latex(label)
@@ -224,7 +224,7 @@ add_footnote <- function(input, label = NULL,
   }
 
   # HTML Tables -------------------
-  if (attr(input, "format") == "html") {
+  if (base::attr(input, "format", exact = TRUE) == "html") {
     # Clean the entry for labels
     table_info <- magic_mirror(input)
     if (escape) {
@@ -256,6 +256,6 @@ add_footnote <- function(input, label = NULL,
     # Paste footer to the table
     export[1] <- gsub("</tbody>\n", paste0("</tbody>\n", footer), export[1])
   }
-  attr(export, "kable_meta") <- table_info
+  base::attr(export, "kable_meta") <- table_info
   return(export)
 }

--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -70,10 +70,10 @@ add_header_above <- function(kable_input, header = NULL,
                              border_left = FALSE, border_right = FALSE) {
   if (is.null(header)) return(kable_input)
 
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
   if (!kable_format %in% c("html", "latex")) {
     warning("Please specify format in kable. kableExtra can customize either ",
@@ -165,7 +165,7 @@ htmlTable_add_header_above <- function(kable_input, header, bold, italic,
   new_header_row <- htmlTable_new_header_generator(
     header, bold, italic, monospace, underline, strikeout, align,
     color, background, font_size, angle, line, line_sep, extra_css,
-    include_empty, attr(kable_input, 'lightable_class')
+    include_empty, base::attr(kable_input, 'lightable_class', exact = TRUE)
   )
   xml_add_child(kable_xml_thead, new_header_row, .where = 0)
   out <- as_kable_xml(body_node)
@@ -346,7 +346,7 @@ pdfTable_add_header_above <- function(kable_input, header, bold, italic,
     table_info$new_header_row <- c(table_info$new_header_row, new_header_split[1])
     table_info$header_df[[length(table_info$header_df) + 1]] <- header
   }
-  attr(out, "kable_meta") <- table_info
+  base::attr(out, "kable_meta") <- table_info
   return(out)
 }
 

--- a/R/add_indent.R
+++ b/R/add_indent.R
@@ -22,10 +22,10 @@ add_indent <- function(kable_input, positions,
   if (!is.numeric(positions)) {
     stop("Positions can only take numeric row numbers (excluding header rows).")
   }
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
 
   if (!kable_format %in% c("html", "latex")) {
@@ -91,7 +91,7 @@ add_indent_latex <- function(kable_input, positions,
     table_info$contents[i] <- new_rowtext
   }
   out <- structure(out, format = "latex", class = "knitr_kable")
-  attr(out, "kable_meta") <- table_info
+  base::attr(out, "kable_meta") <- table_info
   return(out)
 
 
@@ -115,7 +115,7 @@ add_indent_html <- function(kable_input, positions,
   kable_tbody <- xml_tpart(kable_xml, "tbody")
   if (is.null(kable_tbody))
     return(kable_input)
-  group_header_rows <- attr(kable_input, "group_header_rows")
+  group_header_rows <- base::attr(kable_input, "group_header_rows")
   if (!is.null(group_header_rows)) {
     positions <- positions_corrector(positions, group_header_rows,
                                      length(xml_children(kable_tbody)))

--- a/R/as_image.R
+++ b/R/as_image.R
@@ -41,15 +41,15 @@ as_image <- function(x, width = NULL, height = NULL, file = NULL, ...) {
 
   img_dpi <- 300
 
-  if (is.null(width) + is.null(height) <= 1 & is.null(attr(temp_img, "info"))) {
+  if (is.null(width) + is.null(height) <= 1 & is.null(base::attr(temp_img, "info", exact = TRUE))) {
     warning("You need to install magick in order to use width/height in ",
             "as_image. ")
   } else {
     if (!is.null(width)) {
-      img_dpi <- attr(temp_img, "info")$width / width
+      img_dpi <- base::attr(temp_img, "info", exact = TRUE)$width / width
     }
     if (!is.null(height)) {
-      img_dpi <- attr(temp_img, "info")$height / height
+      img_dpi <- base::attr(temp_img, "info", exact = TRUE)$height / height
     }
   }
 

--- a/R/collapse_rows.R
+++ b/R/collapse_rows.R
@@ -56,10 +56,10 @@ collapse_rows <- function(kable_input, columns = NULL,
                           target = NULL,
                           col_names = TRUE,
                           longtable_clean_cut = TRUE) {
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
   if (!kable_format %in% c("html", "latex")) {
     warning("Please specify format in kable. kableExtra can customize either ",
@@ -311,7 +311,7 @@ collapse_rows_latex <- function(kable_input, columns, latex_hline, valign,
   out <- structure(out, format = "latex", class = "knitr_kable")
   table_info$collapse_rows <- TRUE
   table_info$collapse_matrix <- collapse_matrix
-  attr(out, "kable_meta") <- table_info
+  base::attr(out, "kable_meta") <- table_info
   if(row_group_label_position == 'stack'){
     group_row_index_list <- collapse_rows_index(kable_dt, head(columns, -1))
     out <- collapse_rows_latex_stack(out, group_row_index_list, row_group_label_fonts)

--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -78,10 +78,10 @@ column_spec <- function(kable_input, column,
   if (!is.numeric(column)) {
     stop("column must be numeric. ")
   }
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
 
   if (!kable_format %in% c("html", "latex")) {
@@ -127,7 +127,7 @@ column_spec_html <- function(kable_input, column, width,
   if (is.null(kable_tbody))
     return(kable_input)
 
-  group_header_rows <- attr(kable_input, "group_header_rows")
+  group_header_rows <- base::attr(kable_input, "group_header_rows", exact = TRUE)
   all_contents_rows <- seq(1, length(xml_children(kable_tbody)))
 
   if (!is.null(group_header_rows)) {
@@ -314,13 +314,13 @@ column_spec_html_cell <- function(target_cell, width, width_min, width_max,
   # favor popover over tooltip
   if (!is.null(popover)) {
     if (!inherits(popover, "ke_popover")) popover <- spec_popover(popover)
-    popover_list <- lapply(attr(popover, 'list'), enc2utf8)
+    popover_list <- lapply(base::attr(popover, 'list', exact = TRUE), enc2utf8)
     for (p in names(popover_list)) {
       xml_attr(target_cell, p) <- popover_list[p]
     }
   } else if (!is.null(tooltip)) {
     if (!inherits(tooltip, "ke_tooltip")) tooltip <- spec_tooltip(tooltip)
-    tooltip_list <- lapply(attr(tooltip, 'list'), enc2utf8)
+    tooltip_list <- lapply(base::attr(tooltip, 'list', exact = TRUE), enc2utf8)
     for (t in names(tooltip_list)) {
       xml_attr(target_cell, t) <- tooltip_list[t]
     }
@@ -432,7 +432,7 @@ column_spec_latex <- function(kable_input, column, width,
       table_info$column_width[[paste0("column_", i)]] <- width
     }
   }
-  attr(out, "kable_meta") <- table_info
+  base::attr(out, "kable_meta") <- table_info
   return(out)
 }
 

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -74,10 +74,10 @@ footnote <- function(kable_input,
                      title_format = "italic",
                      symbol_manual = NULL
 ) {
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
   if (!kable_format %in% c("html", "latex")) {
     warning("Please specify format in kable. kableExtra can customize either ",
@@ -376,7 +376,7 @@ footnote_latex <- function(kable_input, footnote_table, footnote_as_chunk,
   }
 
   out <- structure(out, format = "latex", class = "knitr_kable")
-  attr(out, "kable_meta") <- table_info
+  base::attr(out, "kable_meta") <- table_info
   return(out)
 }
 

--- a/R/group_rows.R
+++ b/R/group_rows.R
@@ -72,10 +72,10 @@ group_rows <- function(kable_input, group_label = NULL,
                        monospace = FALSE, underline = FALSE, strikeout = FALSE,
                        color = NULL, background = NULL) {
 
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
   if (!kable_format %in% c("html", "latex")) {
     warning("Please specify format in kable. kableExtra can customize either ",
@@ -153,7 +153,7 @@ group_rows_html <- function(kable_input, group_label, start_row, end_row,
     group_label <- escape_html(group_label)
   }
 
-  group_header_rows <- attr(kable_input, "group_header_rows")
+  group_header_rows <- base::attr(kable_input, "group_header_rows", exact = TRUE)
   group_seq <- seq(start_row, end_row)
   if (!is.null(group_header_rows)) {
     group_seq <- positions_corrector(group_seq, group_header_rows,
@@ -174,8 +174,8 @@ group_rows_html <- function(kable_input, group_label, start_row, end_row,
   if (italic) group_label <- paste0("<em>", group_label, "</em>")
 
   if (label_row_css == "border-bottom: 1px solid;") {
-    if (!is.null(attr(kable_input, "lightable_class"))) {
-      lightable_class <- attr(kable_input, "lightable_class")
+    if (!is.null(base::attr(kable_input, "lightable_class", exact = TRUE))) {
+      lightable_class <- base::attr(kable_input, "lightable_class", exact = TRUE)
       if (lightable_class %in% c(
         "lightable-classic", "lightable-classic-2", "lightable-minimal")) {
         label_row_css <- "border-bottom: 0;"
@@ -219,7 +219,7 @@ group_rows_html <- function(kable_input, group_label, start_row, end_row,
   # add indentations to items
   out <- as_kable_xml(body_node)
   attributes(out) <- kable_attrs
-  attr(out, "group_header_rows") <- c(attr(out, "group_header_rows"), group_seq[1])
+  base::attr(out, "group_header_rows") <- c(base::attr(out, "group_header_rows", exact = TRUE), group_seq[1])
   if (indent) {
     out <- add_indent_html(out, positions = seq(start_row, end_row))
   }
@@ -316,7 +316,7 @@ group_rows_latex <- function(kable_input, group_label, start_row, end_row,
   out <- gsub("\\\\addlinespace\n", "", out)
   out <- structure(out, format = "latex", class = "knitr_kable")
   table_info$group_rows_used <- TRUE
-  attr(out, "kable_meta") <- table_info
+  base::attr(out, "kable_meta") <- table_info
   if (indent) {
     out <- add_indent_latex(out, seq(start_row, end_row))
   }

--- a/R/header_separate.R
+++ b/R/header_separate.R
@@ -13,10 +13,10 @@
 #'
 #' @export
 header_separate <- function(kable_input, sep = "[^[:alnum:]]+", ...) {
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
   if (!kable_format %in% c("html", "latex")) {
     warning("Please specify format in kable. kableExtra can customize either ",
@@ -144,7 +144,7 @@ header_separate_latex <- function(kable_input, sep, ...) {
   table_info$contents[1] <- new_header_row_one
 
   out <- structure(out, format = "latex", class = "knitr_kable")
-  attr(out, "kable_meta") <- table_info
+  base::attr(out, "kable_meta") <- table_info
 
   for (l in seq(2, length(header_layers))) {
     out <- do.call(

--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -127,10 +127,10 @@ kable_styling <- function(kable_input,
     font_size <- getOption("kable_styling_font_size", NULL)
   }
 
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
 
   if (!kable_format %in% c("html", "latex")) {
@@ -401,7 +401,7 @@ pdfTable_styling <- function(kable_input,
                                 table.envir, wraptable_width)
 
   out <- structure(out, format = "latex", class = "knitr_kable")
-  attr(out, "kable_meta") <- table_info
+  base::attr(out, "kable_meta") <- table_info
 
   if (row_label_position != "l") {
     if (table_info$tabular == "longtable") {

--- a/R/landscape.R
+++ b/R/landscape.R
@@ -14,10 +14,10 @@
 #'
 #' @export
 landscape <- function(kable_input, margin = NULL) {
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
   if (!kable_format %in% c("html", "latex")) {
     warning("Please specify format in kable. kableExtra can customize either ",
@@ -48,6 +48,6 @@ landscape_latex <- function(kable_input, margin) {
   }
   out <- structure(out, format = "latex", class = "knitr_kable")
   attributes(out) <- kable_attrs
-  attr(out, "landscape") <- TRUE
+  base::attr(out, "landscape") <- TRUE
   return(out)
 }

--- a/R/light_themes.R
+++ b/R/light_themes.R
@@ -80,7 +80,7 @@ kable_light <- function(kable_input, light_class, lightable_options,
   }
   out <- kable_styling(kable_input, "none", htmltable_class = light_class,
                        html_font = html_font, ...)
-  attr(out, "lightable") <- TRUE
-  attr(out, "lightable_class") <- light_class
+  base::attr(out, "lightable") <- TRUE
+  base::attr(out, "lightable_class") <- light_class
   return(out)
 }

--- a/R/magic_mirror.R
+++ b/R/magic_mirror.R
@@ -8,7 +8,7 @@
 #' @export
 
 magic_mirror <- function(kable_input){
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format == "latex") {
     table_info <- magic_mirror_latex(kable_input)
   }
@@ -16,7 +16,7 @@ magic_mirror <- function(kable_input){
     table_info <- magic_mirror_html(kable_input)
   }
   if ("kable_meta" %in% names(attributes(kable_input))) {
-    out <- attr(kable_input, "kable_meta")
+    out <- base::attr(kable_input, "kable_meta", exact = TRUE)
     # if we return `kable_meta` immediately, `kable_styling` will use the
     # original `table_env` value. So if we call `kable_styling` twice on the
     # same object, it will nest a table within a table. Make sure this does not
@@ -98,8 +98,8 @@ magic_mirror_latex <- function(kable_input){
       !str_detect(kable_input, "\\\\begin\\{table\\}\\n\\n\\\\caption")) {
     table_info$contents <- table_info$contents[-1]
   }
-  if (!is.null(attr(kable_input, "n_head"))) {
-    n_head <- attr(kable_input, "n_head")
+  if (!is.null(base::attr(kable_input, "n_head", exact = TRUE))) {
+    n_head <- base::attr(kable_input, "n_head", exact = TRUE)
     table_info$new_header_row <- table_info$contents[seq(n_head - 1, 1)]
     table_info$contents <- table_info$contents[-seq(1, n_head - 1)]
     table_info$header_df <- extra_header_to_header_df(table_info$new_header_row)

--- a/R/remove_column.R
+++ b/R/remove_column.R
@@ -12,10 +12,10 @@
 #' }
 remove_column <- function (kable_input, columns) {
     if (is.null(columns)) return(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
     if (kable_format %in% c("pipe", "markdown")) {
       kable_input <- md_table_parser(kable_input)
-      kable_format <- attr(kable_input, "format")
+      kable_format <- base::attr(kable_input, "format", exact = TRUE)
     }
     if (!kable_format %in% c("html", "latex")) {
         warning("Please specify format in kable. kableExtra can customize",
@@ -42,7 +42,7 @@ remove_column_html <- function (kable_input, columns) {
       return(kable_input)
     kable_thead <- xml_tpart(kable_xml, "thead")
 
-    group_header_rows <- attr(kable_input, "group_header_rows")
+    group_header_rows <- base::attr(kable_input, "group_header_rows", exact = TRUE)
     all_contents_rows <- seq(1, length(xml_children(kable_tbody)))
 
     if (!is.null(group_header_rows)) {
@@ -52,7 +52,7 @@ remove_column_html <- function (kable_input, columns) {
                                                    group_header_rows]
     }
 
-    collapse_matrix <- attr(kable_input, "collapse_matrix")
+    collapse_matrix <- base::attr(kable_input, "collapse_matrix", exact = TRUE)
     collapse_columns <- NULL
     if (!is.null(collapse_matrix)) {
         collapse_columns <- sort(as.numeric(sub("x", "",

--- a/R/row_spec.R
+++ b/R/row_spec.R
@@ -50,10 +50,10 @@ row_spec <- function(kable_input, row,
   if (!is.numeric(row)) {
     stop("row must be numeric. ")
   }
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
   if (!kable_format %in% c("html", "latex")) {
     warning("Please specify format in kable. kableExtra can customize either ",
@@ -111,7 +111,7 @@ row_spec_html <- function(kable_input, row, bold, italic, monospace,
     if (is.null(kable_tbody))
       warning("No table body found")
     else {
-      group_header_rows <- attr(kable_input, "group_header_rows")
+      group_header_rows <- base::attr(kable_input, "group_header_rows", exact = TRUE)
       if (!is.null(group_header_rows)) {
         row <- positions_corrector(row, group_header_rows,
                                    length(xml_children(kable_tbody)))
@@ -243,7 +243,7 @@ row_spec_latex <- function(kable_input, row, bold, italic, monospace,
   }
 
   out <- structure(out, format = "latex", class = "knitr_kable")
-  attr(out, "kable_meta") <- table_info
+  base::attr(out, "kable_meta") <- table_info
   return(out)
 }
 

--- a/R/save_kable.R
+++ b/R/save_kable.R
@@ -35,14 +35,14 @@ save_kable <- function(x, file,
                        latex_header_includes = NULL, keep_tex = FALSE,
                        density = 300) {
 
-  if (!is.null(attr(x, "format"))) {
+  if (!is.null(base::attr(x, "format", exact = TRUE))) {
 
     # latex
-    if (attr(x, "format") == "latex") {
+    if (base::attr(x, "format", exact = TRUE) == "latex") {
       return(save_kable_latex(x, file, latex_header_includes, keep_tex, density))
 
       # markdown
-    } else if (attr(x, "format") == "pipe") {
+    } else if (base::attr(x, "format", exact = TRUE) == "pipe") {
 
       # good file extension: write to file
       if (tools::file_ext(file) %in% c("txt", "md", "markdown", "Rmd")) {
@@ -133,7 +133,7 @@ save_kable_html <- function(x, file, bs_theme, self_contained,
         img_rework <- magick::image_trim(img_rework)
         img_info <- magick::image_info(img_rework)
         magick::image_write(img_rework, file, density = density)
-        attr(file, "info") <- img_info
+        base::attr(file, "info") <- img_info
       } else {
         message("save_kable will have the best result with magick installed. ")
       }
@@ -288,6 +288,6 @@ save_kable_latex <- function(x, file, latex_header_includes, keep_tex, density) 
   }
 
   out <- paste0(file_no_ext, ".", tools::file_ext(file))
-  attr(out, "info") <- table_img_info
+  base::attr(out, "info") <- table_img_info
   return(invisible(out))
 }

--- a/R/scroll_box.R
+++ b/R/scroll_box.R
@@ -31,10 +31,10 @@ scroll_box <- function(kable_input, height = NULL, width = NULL,
                        extra_css = NULL,
                        fixed_thead = TRUE
                        ) {
-  kable_format <- attr(kable_input, "format")
+  kable_format <- base::attr(kable_input, "format", exact = TRUE)
   if (kable_format %in% c("pipe", "markdown")) {
     kable_input <- md_table_parser(kable_input)
-    kable_format <- attr(kable_input, "format")
+    kable_format <- base::attr(kable_input, "format", exact = TRUE)
   }
   if (kable_format != "html") {
     return(kable_input)

--- a/R/spec_tools.R
+++ b/R/spec_tools.R
@@ -150,7 +150,7 @@ spec_tooltip <- function(title, position = "right") {
     'title' = if(is.null(title)) '' else title
   )
   class(tooltip_options) <- "ke_tooltip"
-  attr(tooltip_options, 'list') <- tooltip_options_list
+  base::attr(tooltip_options, 'list') <- tooltip_options_list
   return(tooltip_options)
 }
 
@@ -187,7 +187,7 @@ spec_popover <- function(content = NULL, title = NULL,
     popover_options_list['title'] <- title
   }
   class(popover_options) <- "ke_popover"
-  attr(popover_options, 'list') <- popover_options_list
+  base::attr(popover_options, 'list') <- popover_options_list
   return(popover_options)
 }
 

--- a/R/xtable2kable.R
+++ b/R/xtable2kable.R
@@ -52,6 +52,6 @@ xtable2kable <- function(x, ...) {
     out_meta$tabular <- xtable_print_options$tabular.environment
   }
   out_meta$xtable <- TRUE
-  attr(out, "kable_meta") <- out_meta
+  base::attr(out, "kable_meta") <- out_meta
   return(out)
 }


### PR DESCRIPTION
Fixes #895.

The `xfun` package (loaded by `kableExtra`'s import of `rmarkdown`) masks the base `attr()` function with its own version, which adds the flag `exact = TRUE`. As of xfun 0.52, this functionality has been deprecated and moved into a new function, `attr2()`.

I elected to remove the dependency on `xfun` by explicitly calling `base::attr()` and adding the `exact = TRUE` flag. However, an alternate resolution to this issue would be to instead use `xfun::attr2()`.