### PR TITLE
A better fix for #908 based on the PR #898.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: kableExtra
 Type: Package
 Title: Construct Complex Table with 'kable' and Pipe Syntax
-Version: 1.4.0.16
+Version: 1.4.0.17
 Authors@R: c(
     person('Hao', 'Zhu', email = 'haozhu233@gmail.com', role = c('aut', 'cre'),
     comment = c(ORCID = '0000-0002-3386-6076')),

--- a/R/save_kable.R
+++ b/R/save_kable.R
@@ -239,11 +239,12 @@ save_kable_latex <- function(x, file, latex_header_includes, keep_tex, density) 
   # floats, so extract just the tabular part
   # of the table
   info <- magic_mirror_latex(x)
+  options <- "border=1mm"
   if (info$table_env)
-    x <- extract_tabular(x, info)
+    options <- paste(options, "varwidth", sep = ",")
 
   temp_tex <- c(
-    "\\documentclass[border=1mm]{standalone}",
+    paste0("\\documentclass[", options, "]{standalone}"),
     "\\usepackage{amssymb, amsmath}",
     latex_pkg_list(xelatex = TRUE),
     "\\usepackage{graphicx}",

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,4 +1,4 @@
-kableExtra 1.4.0.16
+kableExtra 1.4.0.17
 --------------------------------------------------------------------------------
 
 Bug Fixes:
@@ -9,7 +9,8 @@ alpha be between 0 and 1, different from R's 0 and 255 (#902).
 that falls within a collapsed label did not render properly in HTML.
 It is now an error to do that; see `?pack_rows` for a workaround (#840).
 * `save_kable()` could fail when a LaTeX table was wrapped in 
-a floating environment.  Now the inner environment is extracted (#908).
+a floating environment.  Now the `varwidth` option is used
+to allow it (#897, #908).
 * `save_kable()` on a LaTeX table processed with `xelatex`
 generated a warning that `inputenc` shouldn't be used.  The
 `kableExtra_latex_packages()` function has gained an extra 


### PR DESCRIPTION
Optionally adds `varwidth` option to `standalone` LaTeX class.