### PR TITLE
Mark sparkline chunk eval=FALSE

### DIFF
--- a/vignettes/awesome_table_in_html.Rmd
+++ b/vignettes/awesome_table_in_html.Rmd
@@ -631,7 +631,7 @@ kbl(mtcars) %>%
 ## Use it with sparkline
 Well, this is not a feature but rather a documentation of how to use the `sparkline` package together with this package. The easiest way is sort of a hack. You can call `sparkline::sparkline(0)` somewhere on your document where no one would mind so its dependencies could be loaded without any hurdles. Then you use `sparkline::spk_chr()` to generate the text. For a working example, see: [Chinese names in US babynames](https://cranky-chandrasekhar-cfefcd.netlify.app/)
 
-```{r}
+```{r, eval=FALSE}
 # Not evaluated
 library(sparkline)
 sparkline::sparkline(0)


### PR DESCRIPTION
The comment says it's not evaluated, but that's not true as of now.

PS WDYT about changing these to ```` ```r ```` chunks instead? Currently {lintr} does not recognize `eval=FALSE` so this is a different way to convey the same thing that {lintr} supports.