### PR TITLE
Fix/917 docx

### DIFF
--- a/R/add_footnote.R
+++ b/R/add_footnote.R
@@ -72,7 +72,7 @@ add_footnote <- function(input, label = NULL,
   # markdown doesn't support complex table formats but this solution
   # should be able to satisfy people who don't want to spend extra
   # time to define their `kable` format.
-  if (!attr(input, "format") %in% c("html", "latex")) {
+  if (!attr(input, "format") %in% c("html", "latex", "docx")) {
     if (notation == "none")
       ids.innote <- ids.intable  # issue #672
     else
@@ -224,7 +224,7 @@ add_footnote <- function(input, label = NULL,
   }
 
   # HTML Tables -------------------
-  if (attr(input, "format") == "html") {
+  if (attr(input, "format") %in% c("html", "docx")) {
     # Clean the entry for labels
     table_info <- magic_mirror(input)
     if (escape) {

--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -75,12 +75,7 @@ add_header_above <- function(kable_input, header = NULL,
     kable_input <- md_table_parser(kable_input)
     kable_format <- attr(kable_input, "format")
   }
-  if (!kable_format %in% c("html", "latex")) {
-    warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
-            "for details.")
-    return(kable_input)
-  }
+  if (!confirm_format(kable_format)) return(kable_input)
   if ((length(align) != 1L) & (length(align) != length(header))) {
     warning("Length of align vector supplied to add_header_above must either be 1 ",
             "or the same length as the header supplied. The length of the align ",

--- a/R/add_header_above.R
+++ b/R/add_header_above.R
@@ -101,7 +101,7 @@ add_header_above <- function(kable_input, header = NULL,
   else {
     header <- standardize_header_input(header)
   }
-  if (kable_format == "html") {
+  if (kable_format %in% c("html", "docx")) {
     return(htmlTable_add_header_above(
       kable_input, header, bold, italic, monospace, underline, strikeout,
       align, color, background, font_size, angle, escape, line, line_sep,

--- a/R/add_indent.R
+++ b/R/add_indent.R
@@ -29,6 +29,7 @@ add_indent <- function(kable_input, positions,
   }
 
   if (!confirm_format(kable_format)) return(kable_input)
+  if (kable_format %in% c("html", "docx")) {
     return(add_indent_html(
       kable_input, positions, level_of_indent, all_cols, target_cols
       ))

--- a/R/add_indent.R
+++ b/R/add_indent.R
@@ -28,13 +28,7 @@ add_indent <- function(kable_input, positions,
     kable_format <- attr(kable_input, "format")
   }
 
-  if (!kable_format %in% c("html", "latex")) {
-    warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
-            "for details.")
-    return(kable_input)
-  }
-  if (kable_format == "html") {
+  if (!confirm_format(kable_format)) return(kable_input)
     return(add_indent_html(
       kable_input, positions, level_of_indent, all_cols, target_cols
       ))

--- a/R/cell_spec.R
+++ b/R/cell_spec.R
@@ -72,7 +72,7 @@ cell_spec <- function(x, format,
       format <- "html"
     }
   }
-  if (tolower(format) == "html") {
+  if (tolower(format) %in% c("html", "docx")) {
     return(cell_spec_html(x, bold, italic, monospace, underline, strikeout,
                           color, background, align, font_size, angle,
                           tooltip, popover, link, new_tab, extra_css,

--- a/R/collapse_rows.R
+++ b/R/collapse_rows.R
@@ -61,12 +61,7 @@ collapse_rows <- function(kable_input, columns = NULL,
     kable_input <- md_table_parser(kable_input)
     kable_format <- attr(kable_input, "format")
   }
-  if (!kable_format %in% c("html", "latex")) {
-    warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
-            "for details.")
-    return(kable_input)
-  }
+  if (!confirm_format(kable_format)) return(kable_input)
   valign <- match.arg(valign)
   if (!is.null(target)) {
     if (length(target) > 1 && is.integer(target)) {

--- a/R/collapse_rows.R
+++ b/R/collapse_rows.R
@@ -68,7 +68,7 @@ collapse_rows <- function(kable_input, columns = NULL,
       stop("target can only be a length 1 integer")
     }
   }
-  if (kable_format == "html") {
+  if (kable_format %in% c("html", "docx")) {
     return(collapse_rows_html(kable_input, columns, valign, target))
   }
   if (kable_format == "latex") {

--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -85,6 +85,7 @@ column_spec <- function(kable_input, column,
   }
 
   if (!confirm_format(kable_format)) return(kable_input)
+  if (kable_format %in% c("html", "docx")) {
     return(column_spec_html(kable_input, column, width,
                             bold, italic, monospace,
                             underline, strikeout,

--- a/R/column_spec.R
+++ b/R/column_spec.R
@@ -84,13 +84,7 @@ column_spec <- function(kable_input, column,
     kable_format <- attr(kable_input, "format")
   }
 
-  if (!kable_format %in% c("html", "latex")) {
-    warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
-            "for details.")
-    return(kable_input)
-  }
-  if (kable_format == "html") {
+  if (!confirm_format(kable_format)) return(kable_input)
     return(column_spec_html(kable_input, column, width,
                             bold, italic, monospace,
                             underline, strikeout,

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -79,12 +79,7 @@ footnote <- function(kable_input,
     kable_input <- md_table_parser(kable_input)
     kable_format <- attr(kable_input, "format")
   }
-  if (!kable_format %in% c("html", "latex")) {
-    warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
-            "for details.")
-    return(kable_input)
-  }
+  if (!confirm_format(kable_format)) return(kable_input)
   if (length(alphabet) > 26) {
     alphabet <- alphabet[1:26]
     warning("Please don't use more than 26 footnotes in table_footnote ",

--- a/R/footnote.R
+++ b/R/footnote.R
@@ -103,7 +103,7 @@ footnote <- function(kable_input,
   footnote_titles <- footnote_titles[footnote_order]
   footnote_contents <- footnote_contents[footnote_order]
   if (escape) {
-    if (kable_format == "html") {
+    if (kable_format %in% c("html", "docx")) {
       footnote_contents <- lapply(footnote_contents, escape_html)
       footnote_titles <- lapply(footnote_titles, escape_html)
     } else {
@@ -120,7 +120,7 @@ footnote <- function(kable_input,
   footnote_table <- footnote_table_maker(
     kable_format, footnote_titles, footnote_contents, symbol_manual
   )
-  if (kable_format == "html") {
+  if (kable_format %in% c("html", "docx")) {
     return(footnote_html(kable_input, footnote_table, footnote_as_chunk))
   }
   if (kable_format == "latex") {
@@ -131,7 +131,7 @@ footnote <- function(kable_input,
 
 footnote_title_format <- function(x, format, title_format) {
   if (x == "") return(x)
-  if (format == "html") {
+  if (format %in% c("html", "docx")) {
     title_style <- ""
     if ("italic" %in% title_format) {
       title_style <- paste0(title_style, "font-style: italic;")

--- a/R/footnote_marker.R
+++ b/R/footnote_marker.R
@@ -36,7 +36,7 @@ footnote_marker_number <- function(x, format, double_escape = FALSE) {
       format <- "html"
     }
   }
-  if (format == "html") {
+  if (format %in% c("html", "docx")) {
     return(paste0("<sup>", x, "</sup>"))
   } else if (!double_escape) {
     return(paste0("\\textsuperscript{", x, "}"))
@@ -56,7 +56,7 @@ footnote_marker_alphabet <- function(x, format, double_escape = FALSE) {
     }
   }
   if (is.numeric(x)) x <- letters[x]
-  if (format == "html") {
+  if (format %in% c("html", "docx")) {
     return(paste0("<sup>", x, "</sup>"))
   } else if (!double_escape) {
     return(paste0("\\textsuperscript{", x, "}"))
@@ -77,7 +77,7 @@ footnote_marker_symbol <- function(x, format, double_escape = FALSE) {
   }
   number_index <- read.csv(system.file("symbol_index.csv",
                                        package = "kableExtra"))
-  if (format == "html") {
+  if (format %in% c("html", "docx")) {
     x <- number_index$symbol.html[x]
     return(paste0("<sup>", x, "</sup>"))
   } else if (!double_escape) {

--- a/R/group_rows.R
+++ b/R/group_rows.R
@@ -91,7 +91,7 @@ group_rows <- function(kable_input, group_label = NULL,
   if (!confirm_format(kable_format)) return(kable_input)
 
   if (is.null(index)) {
-    if (kable_format == "html") {
+    if (kable_format %in% c("html", "docx")) {
       if (!missing(latex_align)) warning("latex_align parameter is not used in HTML Mode,
                                     use label_row_css instead.")
       return(group_rows_html(kable_input, group_label, start_row, end_row,
@@ -109,7 +109,7 @@ group_rows <- function(kable_input, group_label = NULL,
   } else {
     index <- group_row_index_translator(index)
     out <- kable_input
-    if (kable_format == "html") {
+    if (kable_format %in% c("html", "docx")) {
       for (i in 1:nrow(index)) {
         if (!missing(latex_align)) warning("latex_align parameter is not used in HTML Mode,
                                     use label_row_css instead.")

--- a/R/group_rows.R
+++ b/R/group_rows.R
@@ -88,12 +88,7 @@ group_rows <- function(kable_input, group_label = NULL,
     kable_input <- md_table_parser(kable_input)
     kable_format <- attr(kable_input, "format")
   }
-  if (!kable_format %in% c("html", "latex")) {
-    warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
-            "for details.")
-    return(kable_input)
-  }
+  if (!confirm_format(kable_format)) return(kable_input)
 
   if (is.null(index)) {
     if (kable_format == "html") {

--- a/R/header_separate.R
+++ b/R/header_separate.R
@@ -18,13 +18,7 @@ header_separate <- function(kable_input, sep = "[^[:alnum:]]+", ...) {
     kable_input <- md_table_parser(kable_input)
     kable_format <- attr(kable_input, "format")
   }
-  if (!kable_format %in% c("html", "latex")) {
-    warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
-            "for details.")
-    return(kable_input)
-  }
-  if (kable_format == "html") {
+  if (!confirm_format(kable_format)) return(kable_input)
     return(do.call(header_separate_html, list(
       kable_input = kable_input,
       sep = sep,

--- a/R/header_separate.R
+++ b/R/header_separate.R
@@ -19,6 +19,7 @@ header_separate <- function(kable_input, sep = "[^[:alnum:]]+", ...) {
     kable_format <- attr(kable_input, "format")
   }
   if (!confirm_format(kable_format)) return(kable_input)
+  if (kable_format %in% c("html", "docx")) {
     return(do.call(header_separate_html, list(
       kable_input = kable_input,
       sep = sep,

--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -133,13 +133,7 @@ kable_styling <- function(kable_input,
     kable_format <- attr(kable_input, "format")
   }
 
-  if (!kable_format %in% c("html", "latex")) {
-    warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
-            "for details.")
-    return(kable_input)
-  }
-  if (kable_format == "html") {
+  if (!confirm_format(kable_format)) return(kable_input)
     if (is.null(full_width)) {
       full_width <- getOption("kable_styling_full_width", T)
     }

--- a/R/kable_styling.R
+++ b/R/kable_styling.R
@@ -134,6 +134,7 @@ kable_styling <- function(kable_input,
   }
 
   if (!confirm_format(kable_format)) return(kable_input)
+  if (kable_format %in% c("html", "docx")) {
     if (is.null(full_width)) {
       full_width <- getOption("kable_styling_full_width", T)
     }

--- a/R/kbl.R
+++ b/R/kbl.R
@@ -110,14 +110,15 @@ kbl <- function(x, format, digits = getOption("digits"),
       midrule = midrule, linesep = linesep, caption.short = caption.short,
       table.envir = table.envir, ...
     )
-  } else if (format == "html") {
+  } else if (format %in% c("html", "docx")) {
     out <- knitr::kable(
-      x = x, format = format, digits = digits,
+      x = x, format = "html", digits = digits,
       row.names = row.names, col.names = col.names, align = align,
       caption = caption, label = label, format.args = format.args,
       escape = escape,
       table.attr = table.attr, ...
     )
+    attr(out, "format") <- format
     if (!"kableExtra" %in% class(out)) class(out) <- c("kableExtra", class(out))
   } else
     out <- knitr::kable(

--- a/R/landscape.R
+++ b/R/landscape.R
@@ -20,6 +20,7 @@ landscape <- function(kable_input, margin = NULL) {
     kable_format <- attr(kable_input, "format")
   }
   if (!confirm_format(kable_format)) return(kable_input)
+  if (kable_format %in% c("html", "docx")) {
     return(kable_input)
   }
   if (kable_format == "latex") {

--- a/R/landscape.R
+++ b/R/landscape.R
@@ -19,13 +19,7 @@ landscape <- function(kable_input, margin = NULL) {
     kable_input <- md_table_parser(kable_input)
     kable_format <- attr(kable_input, "format")
   }
-  if (!kable_format %in% c("html", "latex")) {
-    warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
-            "for details.")
-    return(kable_input)
-  }
-  if (kable_format == "html") {
+  if (!confirm_format(kable_format)) return(kable_input)
     return(kable_input)
   }
   if (kable_format == "latex") {

--- a/R/magic_mirror.R
+++ b/R/magic_mirror.R
@@ -12,7 +12,7 @@ magic_mirror <- function(kable_input){
   if (kable_format == "latex") {
     table_info <- magic_mirror_latex(kable_input)
   }
-  if (kable_format == "html") {
+  if (kable_format %in% c("html", "docx")) {
     table_info <- magic_mirror_html(kable_input)
   }
   if ("kable_meta" %in% names(attributes(kable_input))) {

--- a/R/print.R
+++ b/R/print.R
@@ -17,6 +17,8 @@ print.kableExtra <- function(x, ...) {
     htmlDependencies(html_kable) <- dep
     class(html_kable) <- "shiny.tag.list"
     print(html_kable)
+  } else if (attr(x, "format") == "docx") {
+    webshot_table_to_png(x)
   } else {
     cat(as.character(x))
   }
@@ -70,6 +72,9 @@ html_dependency_lightable <- function() {
 
 #' @export
 knit_print.kableExtra <- function(x, ...) {
+  if (attr(x, "format") == "docx") {
+    return(include_graphics(save_kable_png(x)))
+  }
   x <- paste0(x, "\n\n")
   kp_dependency <- getOption("kableExtra.knit_print.dependency",
                              default = TRUE)

--- a/R/remove_column.R
+++ b/R/remove_column.R
@@ -20,7 +20,7 @@ remove_column <- function (kable_input, columns) {
     if (!confirm_format(kable_format)) return(kable_input)
 
     columns <- sort(unique(columns))
-    if (kable_format == "html") {
+    if (kable_format %in% c("html", "docx")) {
         return(remove_column_html(kable_input, columns))
     } else if (kable_format == "latex") {
         stop("Removing columns was not implemented for latex kables yet")

--- a/R/remove_column.R
+++ b/R/remove_column.R
@@ -17,12 +17,7 @@ remove_column <- function (kable_input, columns) {
       kable_input <- md_table_parser(kable_input)
       kable_format <- attr(kable_input, "format")
     }
-    if (!kable_format %in% c("html", "latex")) {
-        warning("Please specify format in kable. kableExtra can customize",
-                " either HTML or LaTeX outputs. See ",
-                "https://haozhu233.github.io/kableExtra/ for details.")
-        return(kable_input)
-    }
+    if (!confirm_format(kable_format)) return(kable_input)
 
     columns <- sort(unique(columns))
     if (kable_format == "html") {

--- a/R/row_spec.R
+++ b/R/row_spec.R
@@ -56,6 +56,7 @@ row_spec <- function(kable_input, row,
     kable_format <- attr(kable_input, "format")
   }
   if (!confirm_format(kable_format)) return(kable_input)
+  if (kable_format %in% c("html", "docx")) {
     return(row_spec_html(kable_input, row, bold, italic, monospace,
                          underline, strikeout,
                          color, background, align, font_size, angle,

--- a/R/row_spec.R
+++ b/R/row_spec.R
@@ -55,13 +55,7 @@ row_spec <- function(kable_input, row,
     kable_input <- md_table_parser(kable_input)
     kable_format <- attr(kable_input, "format")
   }
-  if (!kable_format %in% c("html", "latex")) {
-    warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
-            "for details.")
-    return(kable_input)
-  }
-  if (kable_format == "html") {
+  if (!confirm_format(kable_format)) return(kable_input)
     return(row_spec_html(kable_input, row, bold, italic, monospace,
                          underline, strikeout,
                          color, background, align, font_size, angle,

--- a/R/save_kable.R
+++ b/R/save_kable.R
@@ -41,6 +41,10 @@ save_kable <- function(x, file,
     if (attr(x, "format") == "latex") {
       return(save_kable_latex(x, file, latex_header_includes, keep_tex, density))
 
+      # docx
+    } else if (attr(x, "format") == "docx") {
+      return(save_kable_png(x, file, ...))
+
       # markdown
     } else if (attr(x, "format") == "pipe") {
 
@@ -163,6 +167,17 @@ save_kable_html <- function(x, file, bs_theme, self_contained,
   }
 
   return(invisible(file))
+}
+
+save_kable_png <- function(x, file, ...) {
+  fn <- tempfile(fileext = ".html")
+  on.exit(unlink(fn))
+  writeLines(x, fn)
+  if (missing(file)) file <- tempfile(fileext = ".png")
+  dots <- list(...)
+  if (!"selector" %in% names(dots)) dots$selector <- "table"
+  do.call(webshot2::webshot, c(list(url = fn, file = file), dots))
+  invisible(file)
 }
 
 # Local version of htmltools::save_html with fix to relative path.

--- a/R/scroll_box.R
+++ b/R/scroll_box.R
@@ -36,7 +36,7 @@ scroll_box <- function(kable_input, height = NULL, width = NULL,
     kable_input <- md_table_parser(kable_input)
     kable_format <- attr(kable_input, "format")
   }
-  if (kable_format != "html") {
+  if (!kable_format %in% c("html", "docx")) {
     return(kable_input)
   }
   kable_attrs <- attributes(kable_input)
@@ -77,7 +77,7 @@ scroll_box <- function(kable_input, height = NULL, width = NULL,
 
   out <- paste0('<div style="', paste(box_styles, collapse = ""), '">',
                 out, '</div>')
-  out <- structure(out, format = "html",
+  out <- structure(out, format = kable_format,
                    class = "knitr_kable")
   attributes(out) <- kable_attrs
 

--- a/R/util.R
+++ b/R/util.R
@@ -387,7 +387,7 @@ finalize_latex <- function(out, kable_attrs, table_info) {
 confirm_format <- function(kable_format) {
   if (!kable_format %in% c("html", "latex", "docx")) {
     warning("Please specify format in kable. kableExtra can customize either ",
-            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
+            "HTML, LaTeX, or DOCX outputs. See https://haozhu233.github.io/kableExtra/ ",
             "for details.")
     FALSE
   } else TRUE

--- a/R/util.R
+++ b/R/util.R
@@ -383,3 +383,12 @@ finalize_latex <- function(out, kable_attrs, table_info) {
   attr(out, "kable_meta") <- table_info
   out
 }
+
+confirm_format <- function(kable_format) {
+  if (!kable_format %in% c("html", "latex", "docx")) {
+    warning("Please specify format in kable. kableExtra can customize either ",
+            "HTML or LaTeX outputs. See https://haozhu233.github.io/kableExtra/ ",
+            "for details.")
+    FALSE
+  } else TRUE
+}

--- a/R/xtable2kable.R
+++ b/R/xtable2kable.R
@@ -35,8 +35,8 @@ xtable2kable <- function(x, ...) {
 
   xtable_print_options <- list(...)
   if ("type" %in% names(xtable_print_options) &&
-      xtable_print_options$type == "html") {
-    out <- structure(out, format = "html", class = "knitr_kable")
+      xtable_print_options$type %in% c("html", "docx")) {
+    out <- structure(out, format = xtable_print_options$type, class = "knitr_kable")
     return(out)
   }
 

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,3 +1,12 @@
+kableExtra 1.4.0.20
+--------------------------------------------------------------------------------
+
+New Features:
+
+* added "docx" to the list of supported formats, which treats it
+internally as HTML the entire path until rendering into a docx file,
+then it uses `webshot2` to insert a PNG (@r2evans #917)
+
 kableExtra 1.4.0.19
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
fix #917 

This PR supports inline use,

```r
kableExtra::kbl(mtcars[1:8, 1:4], booktabs = TRUE, linesep = "", format = "docx") |>
  kableExtra::kable_styling(latex_options = "striped", stripe_index = c(1,2, 5:6)) |>
  save_kable("foo.png")
# file:////private/var/folders/3f/0hlmq7rx34ddjqtlc1lqbxl80000gn/T/RtmpvBKq7w/fileaa143902958.html screenshot completed
# [1] "foo.png"
```

as well as Rmd rendering

````
---
title: "Use kable for DOCX"
output: rmarkdown::word_document
---

```{r}
kableExtra::kbl(mtcars[1:8, 1:4], booktabs = TRUE, linesep = "", format = "docx") |>
  kableExtra::kable_styling(latex_options = "striped", stripe_index = c(1,2, 5:6))
```
````

```r
rmarkdown::render("vignettes/use_kable_in_docx.Rmd", output_file="foo.docx")
```

Caveat: I did a global search for `format == "html"` and shifted to `%in% c(..)`, I do not know if that might not be desired in all cases. Also, the first commit here centralized the warning to reduce how many places to go for updating it (it made sense, I can pull it back if you don't like it).